### PR TITLE
fix(tx): bind ReadTransaction iterators to transaction lifetime

### DIFF
--- a/src/tx/keyspace.rs
+++ b/src/tx/keyspace.rs
@@ -48,10 +48,10 @@ impl TxKeyspace {
     pub fn read_tx(&self) -> ReadTransaction {
         let instant = self.inner.instant();
 
-        ReadTransaction::new(SnapshotNonce::new(
-            instant,
-            self.inner.snapshot_tracker.clone(),
-        ))
+        ReadTransaction::new(
+            SnapshotNonce::new(instant, self.inner.snapshot_tracker.clone()),
+            &self.inner,
+        )
     }
 
     /// Flushes the active journal. The durability depends on the [`PersistMode`]


### PR DESCRIPTION
Modified the `ReadTransaction` struct to bind its iterators to the transaction's lifetime. 
It improves memory safety by ensuring iterators can't outlive their associated `ReadTransaction`.