### PR TITLE
feat: ignore files while recovering partitions to ignore files 

### DIFF
--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -30,14 +30,9 @@ pub fn recover_partitions(keyspace: &Keyspace) -> crate::Result<()> {
         let partition_name = dirent.file_name();
         let partition_path = dirent.path();
 
-        if dirent.file_type()?.is_file() {
-            continue;
+        if !dirent.file_type()?.is_dir() {
+            log::warn!("Found stray file in partitions folder");
         }
-
-        assert!(
-            dirent.file_type()?.is_dir(),
-            "Found stray file in partitions folder",
-        );
 
         log::trace!("Recovering partition {:?}", partition_name);
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -31,7 +31,7 @@ pub fn recover_partitions(keyspace: &Keyspace) -> crate::Result<()> {
         let partition_path = dirent.path();
 
         if !dirent.file_type()?.is_dir() {
-            log::warn!("Found stray file in partitions folder");
+            log::warn!("Found stray file {partition_path:?} in partitions folder");
             continue;
         }
 

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -30,6 +30,10 @@ pub fn recover_partitions(keyspace: &Keyspace) -> crate::Result<()> {
         let partition_name = dirent.file_name();
         let partition_path = dirent.path();
 
+        if dirent.file_type()?.is_file() {
+            continue;
+        }
+
         assert!(
             dirent.file_type()?.is_dir(),
             "Found stray file in partitions folder",

--- a/src/recovery.rs
+++ b/src/recovery.rs
@@ -32,6 +32,7 @@ pub fn recover_partitions(keyspace: &Keyspace) -> crate::Result<()> {
 
         if !dirent.file_type()?.is_dir() {
             log::warn!("Found stray file in partitions folder");
+            continue;
         }
 
         log::trace!("Recovering partition {:?}", partition_name);


### PR DESCRIPTION
Ignore files like DS_Store. The recovery is panicking if there is a DS_Store file in partitions folder and will continue to do so if there will be any file present in the folder.