### PR TITLE
Impl Error::source

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,20 @@ impl From<lsm_tree::Error> for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Storage(inner) => Some(inner),
+            Self::Io(inner) => Some(inner),
+            Self::Encode(inner) => Some(inner),
+            Self::Decode(inner) => Some(inner),
+            Self::JournalRecovery(inner) => Some(inner),
+            Self::InvalidVersion(_) => None,
+            Self::Poisoned => None,
+            Self::PartitionDeleted => None,
+        }
+    }
+}
 
 /// Result helper type
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/journal/error.rs
+++ b/src/journal/error.rs
@@ -39,3 +39,11 @@ pub enum RecoveryError {
     /// The checksum value does not match the expected value
     ChecksumMismatch,
 }
+
+impl std::fmt::Display for RecoveryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RecoveryError({:?})", self)
+    }
+}
+
+impl std::error::Error for RecoveryError {}


### PR DESCRIPTION
By implementing Error::source, it allows a user to extract io::Errors without importing all fjall crates and manually spidering Fjall's error enums.

Depends on https://github.com/fjall-rs/lsm-tree/pull/111