### PR TITLE
Count how many compactions were performed.

### DIFF
--- a/src/compaction/worker.rs
+++ b/src/compaction/worker.rs
@@ -43,6 +43,7 @@ pub fn run(
         .fetch_add(start.elapsed().as_micros() as u64, Relaxed);
 
     stats.active_compaction_count.fetch_sub(1, Relaxed);
+    stats.compactions_completed.fetch_add(1, Relaxed);
 
     // TODO: loop if there's more work to do
 }

--- a/src/keyspace.rs
+++ b/src/keyspace.rs
@@ -224,6 +224,15 @@ impl Keyspace {
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Returns the amount of completed compactions.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn compactions_completed(&self) -> usize {
+        self.stats
+            .compactions_completed
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Returns the amount of journals on disk.
     ///
     /// # Examples

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -17,6 +17,9 @@ pub struct Stats {
 
     /// Number of completed memtable flushes
     pub(crate) flushes_completed: AtomicUsize,
+
+    /// Number of completed compactions
+    pub(crate) compactions_completed: AtomicUsize,
 }
 
 impl Stats {


### PR DESCRIPTION
Reference issue is #158
Added variable `compactions_completed` to `stats::Stats` to count the number of compactions completed.