### PR TITLE
Count how many flushes performed by partition.

### DIFF
--- a/src/flush/worker.rs
+++ b/src/flush/worker.rs
@@ -161,6 +161,10 @@ pub fn run(
                     stats
                         .flushes_completed
                         .fetch_add(created_segments.len(), std::sync::atomic::Ordering::Relaxed);
+
+                    partition
+                        .flushes_completed
+                        .fetch_add(created_segments.len(), std::sync::atomic::Ordering::Relaxed);
                 }
             }
             Err(e) => {


### PR DESCRIPTION
Reference issue is #158

I added the variable `flushes_by_partition`(`HashMap<PartitionKey, AtomicUsize>`) in `stats::Stats` to count the number of flushes by partition.  
When a flush is performed, Value of HashMap is incremented corresponding to the PartitionKey.