### PR TITLE
Replace path-absolutize with std function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ lsm-tree = { version = "~2.10.3", default-features = false, features = [] }
 log = "0.4.21"
 std-semaphore = "0.1.0"
 tempfile = "3.10.1"
-path-absolutize = "3.1.1"
 dashmap = "6.0.1"
 xxhash-rust = { version = "0.8.12", features = ["xxh3"] }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -2,14 +2,9 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
-use path_absolutize::Absolutize;
 use std::path::{Path, PathBuf};
 
 #[allow(clippy::module_name_repetitions)]
 pub fn absolute_path<P: AsRef<Path>>(path: P) -> PathBuf {
-    // TODO: replace with https://doc.rust-lang.org/std/path/fn.absolute.html once stable
-    path.as_ref()
-        .absolutize()
-        .expect("should be absolute path")
-        .into()
+    std::path::absolute(path).expect("should be absolute path")
 }


### PR DESCRIPTION
`std::path::absolute` was stabilized last year in version 1.79, so the dependency can be removed :)