### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,8 @@ cargo add fjall
 
 ```rust
 use fjall::{Database, KeyspaceCreateOptions, PersistMode};
-use std::path::Path;
 
-fn example(path: impl AsRef<Path>) -> fjall::Result<()> {
+fn main() -> fjall::Result<()> {
     // A database may contain multiple keyspaces
     // You should probably only use a single database for your application
     let db = Database::builder(path).open()?;


### PR DESCRIPTION
Hi Marvin, thank you for developing Fjall!

This PR contains three minor fixes:

* The example code has been wrapped in `fn example` (otherwise the IDEs complain that the snippet is not valid Rust because `let` declarations are not allowed at the top level, only in functions).
* The `persist` call has been fixed: `keyspace.persist` -> `db.persist`
* The type names have been fixed:
  * `OptimisticTransactionDatabase` -> `OptimisticTxDatabase`
  * `SingleWriterTransactionDatabase ` -> `SingleWriterTxDatabase `