### PR TITLE
Remove the Errors section from functions that don't return errors

### DIFF
--- a/src/keyspace/mod.rs
+++ b/src/keyspace/mod.rs
@@ -605,10 +605,6 @@ impl Keyspace {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub fn first_key_value(&self) -> Option<Guard> {
         self.tree.first_key_value(SeqNo::MAX, None).map(Guard)
     }
@@ -633,10 +629,6 @@ impl Keyspace {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub fn last_key_value(&self) -> Option<Guard> {
         self.tree.last_key_value(SeqNo::MAX, None).map(Guard)
     }

--- a/src/readable.rs
+++ b/src/readable.rs
@@ -91,10 +91,6 @@ pub trait Readable {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     fn first_key_value(&self, keyspace: impl AsRef<Keyspace>) -> Option<Guard>;
 
     /// Returns the last key-value pair in the snapshot.
@@ -117,10 +113,6 @@ pub trait Readable {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     fn last_key_value(&self, keyspace: impl AsRef<Keyspace>) -> Option<Guard>;
 
     /// Retrieves the size of an item from the snapshot.

--- a/src/tx/optimistic/keyspace.rs
+++ b/src/tx/optimistic/keyspace.rs
@@ -433,10 +433,6 @@ impl OptimisticTxKeyspace {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     #[must_use]
     pub fn first_key_value(&self) -> Option<Guard> {
         let read_tx = self.db.read_tx();
@@ -463,10 +459,6 @@ impl OptimisticTxKeyspace {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     #[must_use]
     pub fn last_key_value(&self) -> Option<Guard> {
         let read_tx = self.db.read_tx();

--- a/src/tx/optimistic/write_tx.rs
+++ b/src/tx/optimistic/write_tx.rs
@@ -335,10 +335,6 @@ impl WriteTransaction {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub fn insert<K: Into<UserKey>, V: Into<UserValue>>(
         &mut self,
         keyspace: impl AsRef<Keyspace>,
@@ -382,10 +378,6 @@ impl WriteTransaction {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub fn remove<K: Into<UserKey>>(&mut self, keyspace: impl AsRef<Keyspace>, key: K) {
         let keyspace = keyspace.as_ref();
         let key: UserKey = key.into();
@@ -430,10 +422,6 @@ impl WriteTransaction {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     #[doc(hidden)]
     pub fn remove_weak<K: Into<UserKey>>(&mut self, keyspace: impl AsRef<Keyspace>, key: K) {
         let keyspace = keyspace.as_ref();

--- a/src/tx/single_writer/keyspace.rs
+++ b/src/tx/single_writer/keyspace.rs
@@ -412,10 +412,6 @@ impl SingleWriterTxKeyspace {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     #[must_use]
     pub fn first_key_value(&self) -> Option<Guard> {
         let read_tx = self.db.read_tx();
@@ -442,10 +438,6 @@ impl SingleWriterTxKeyspace {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     #[must_use]
     pub fn last_key_value(&self) -> Option<Guard> {
         let read_tx = self.db.read_tx();

--- a/src/tx/single_writer/write_tx.rs
+++ b/src/tx/single_writer/write_tx.rs
@@ -7,7 +7,7 @@ use crate::{
     tx::{single_writer::keyspace::SingleWriterTxKeyspace, write_tx::BaseTransaction},
     Guard, Iter, Keyspace, PersistMode, Readable, SingleWriterTxDatabase,
 };
-use lsm_tree::{KvPair, UserKey, UserValue};
+use lsm_tree::{UserKey, UserValue};
 use std::{ops::RangeBounds, sync::MutexGuard};
 
 /// A single-writer (serialized) cross-keyspace transaction
@@ -274,10 +274,6 @@ impl<'tx> WriteTransaction<'tx> {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub fn insert<K: Into<UserKey>, V: Into<UserValue>>(
         &mut self,
         keyspace: &SingleWriterTxKeyspace,
@@ -317,10 +313,6 @@ impl<'tx> WriteTransaction<'tx> {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub fn remove<K: Into<UserKey>>(&mut self, keyspace: &SingleWriterTxKeyspace, key: K) {
         self.inner.remove(keyspace.inner(), key);
     }
@@ -361,10 +353,6 @@ impl<'tx> WriteTransaction<'tx> {
     /// #
     /// # Ok::<(), fjall::Error>(())
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     #[doc(hidden)]
     pub fn remove_weak<K: Into<UserKey>>(&mut self, keyspace: &SingleWriterTxKeyspace, key: K) {
         self.inner.remove_weak(keyspace.inner(), key);

--- a/src/tx/write_tx.rs
+++ b/src/tx/write_tx.rs
@@ -258,10 +258,6 @@ impl BaseTransaction {
     /// Shorter keys and values result in better performance.
     ///
     /// If the key already exists, the item will be overwritten.
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub(super) fn insert<K: Into<UserKey>, V: Into<UserValue>>(
         &mut self,
         keyspace: &Keyspace,
@@ -285,10 +281,6 @@ impl BaseTransaction {
     ///
     /// The key may be up to 65536 bytes long.
     /// Shorter keys result in better performance.
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub(super) fn remove<K: Into<UserKey>>(&mut self, keyspace: &Keyspace, key: K) {
         self.memtables
             .entry(keyspace.clone())
@@ -307,10 +299,6 @@ impl BaseTransaction {
     ///
     /// The key may be up to 65536 bytes long.
     /// Shorter keys result in better performance.
-    ///
-    /// # Errors
-    ///
-    /// Will return `Err` if an IO error occurs.
     pub(super) fn remove_weak<K: Into<UserKey>>(&mut self, keyspace: &Keyspace, key: K) {
         self.memtables
             .entry(keyspace.clone())


### PR DESCRIPTION
Hi Marvin,

This doc-level PR removes the `Errors` section from infallible functions. I first noticed an issue with `insert` as it didn't return any errors, and then went ahead and removed the `Errors` section from some other infallible fns as well.