### PR TITLE
Fix lock file open mode for filesystem locking

### DIFF
--- a/src/locked_file.rs
+++ b/src/locked_file.rs
@@ -33,10 +33,9 @@ impl LockedFileGuard {
 
         let file = match File::create_new(path) {
             Ok(f) => f,
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(path)?,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                OpenOptions::new().read(true).write(true).open(path)?
+            }
             e => e?,
         };
 
@@ -79,5 +78,35 @@ impl LockedFileGuard {
         }
 
         Ok(Self(Arc::new(LockedFileGuardInner(file))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LockedFileGuard;
+    use std::fs::File;
+
+    #[test]
+    fn create_new_acquires_lock_when_file_already_exists() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("lock");
+
+        File::create(&path)?;
+
+        let _guard = LockedFileGuard::create_new(&path)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn try_acquire_acquires_lock_on_existing_file() -> crate::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("lock");
+
+        File::create(&path)?;
+
+        let _guard = LockedFileGuard::try_acquire(&path)?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Some stricter filesystem implementations reject locking on read-only file descriptors. Opening with write-capable access makes lock acquisition portable and reliable.

  - switch lock-file open paths from read-only File::open to OpenOptions with read(true).write(true)
  - apply this to both LockedFileGuard::create_new (already-exists path) and LockedFileGuard::try_acquire
  - keep existing lock acquisition/retry/error behavior unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved file locking mechanism to correctly handle access permissions when lock files already exist or are being reacquired, ensuring more reliable operation in concurrent file scenarios.

**Tests**
- Added unit tests verifying lock file creation and acquisition behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fjall-rs/fjall/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->