### PR TITLE
Use Server-Timing header in examples instead of x-took-ms

### DIFF
--- a/examples/actix-kv/src/main.rs
+++ b/examples/actix-kv/src/main.rs
@@ -63,7 +63,7 @@ async fn insert_batch(
     .unwrap()?;
 
     Ok(HttpResponse::Ok()
-        .append_header(("x-took-ms", before.elapsed().as_millis().to_string()))
+        .append_header(("server-timing", format!("total;dur={}", before.elapsed().as_millis())))
         .body("OK"))
 }
 
@@ -85,7 +85,7 @@ async fn delete_item(
     .unwrap()?;
 
     Ok(HttpResponse::Ok()
-        .append_header(("x-took-ms", before.elapsed().as_millis().to_string()))
+        .append_header(("server-timing", format!("total;dur={}", before.elapsed().as_millis())))
         .body("OK"))
 }
 
@@ -113,7 +113,7 @@ async fn insert_item(
     .unwrap()?;
 
     Ok(HttpResponse::Created()
-        .append_header(("x-took-ms", before.elapsed().as_millis().to_string()))
+        .append_header(("server-timing", format!("total;dur={}", before.elapsed().as_millis())))
         .body("Created"))
 }
 
@@ -139,7 +139,7 @@ async fn get_item(
             let body = actix_web::body::BoxBody::new(actix_web::web::Bytes::from(item));
 
             Ok(HttpResponse::Ok()
-                .append_header(("x-took-ms", before.elapsed().as_millis().to_string()))
+                .append_header(("server-timing", format!("total;dur={}", before.elapsed().as_millis())))
                 .content_type("application/json; utf-8")
                 .body(body))
         }
@@ -147,7 +147,7 @@ async fn get_item(
             let body = json!(null);
 
             Ok(HttpResponse::NotFound()
-                .append_header(("x-took-ms", before.elapsed().as_millis().to_string()))
+                .append_header(("server-timing", format!("total;dur={}", before.elapsed().as_millis())))
                 .content_type("application/json; utf-8")
                 .body(serde_json::to_string(&body).unwrap()))
         }

--- a/examples/axum-kv/src/main.rs
+++ b/examples/axum-kv/src/main.rs
@@ -65,8 +65,8 @@ async fn insert_batch(
     Ok((
         StatusCode::OK,
         [(
-            HeaderName::from_bytes(b"x-took-ms").unwrap(),
-            before.elapsed().as_millis().to_string(),
+            HeaderName::from_static("server-timing"),
+            format!("total;dur={}", before.elapsed().as_millis()),
         )],
         "OK",
     ))
@@ -90,8 +90,8 @@ async fn delete_item(
     Ok((
         StatusCode::OK,
         [(
-            HeaderName::from_bytes(b"x-took-ms").unwrap(),
-            before.elapsed().as_millis().to_string(),
+            HeaderName::from_static("server-timing"),
+            format!("total;dur={}", before.elapsed().as_millis()),
         )],
         "OK",
     ))
@@ -122,8 +122,8 @@ async fn insert_item(
     Ok((
         StatusCode::CREATED,
         [(
-            HeaderName::from_bytes(b"x-took-ms").unwrap(),
-            before.elapsed().as_millis().to_string(),
+            HeaderName::from_static("server-timing"),
+            format!("total;dur={}", before.elapsed().as_millis()),
         )],
         "Created",
     ))
@@ -146,8 +146,8 @@ async fn get_item(
             StatusCode::OK,
             [
                 (
-                    HeaderName::from_bytes(b"x-took-ms").unwrap(),
-                    before.elapsed().as_millis().to_string(),
+                    HeaderName::from_static("server-timing"),
+                    format!("total;dur={}", before.elapsed().as_millis()),
                 ),
                 (header::CONTENT_TYPE, mime::APPLICATION_JSON.to_string()),
             ],
@@ -157,8 +157,8 @@ async fn get_item(
             StatusCode::NOT_FOUND,
             [
                 (
-                    HeaderName::from_bytes(b"x-took-ms").unwrap(),
-                    before.elapsed().as_millis().to_string(),
+                    HeaderName::from_static("server-timing"),
+                    format!("total;dur={}", before.elapsed().as_millis()),
                 ),
                 (header::CONTENT_TYPE, mime::APPLICATION_JSON.to_string()),
             ],


### PR DESCRIPTION
_Note: this only affects the examples and has no impact on the library itself._

`x-took-ms` is a non-standard header with no widely-recognised semantics. This replaces it with https://www.w3.org/TR/server-timing/, a W3C standard for communicating server-side
  performance metrics to clients.

A practical benefit is that browsers expose `Server-Timing` values natively in DevTools under the Network tab's Timing panel, making it easier to inspect request durations without
  custom tooling.

The value follows the standard format: `total;dur=<milliseconds>`.
  
