### PR TITLE
fix: prevent deadlock in DatabaseInner::drop under write pressure

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,7 @@
 [profile.default]
 slow-timeout = { period = "5s", terminate-after = 3 }
+
+# Stress tests need more time (especially on slow CI runners / Windows)
+[[profile.default.overrides]]
+filter = "test(drop_completes_under_write_pressure)"
+slow-timeout = { period = "30s", terminate-after = 2 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -71,13 +71,17 @@ impl Drop for DatabaseInner {
 
         let _ = self.worker_pool.rx.drain().count();
 
+        // Workers have two independent exit paths: (1) stop_signal checked on
+        // every tick via recv_timeout, and (2) Close message in the channel.
+        // try_send(Close) is best-effort — if the channel is full, workers will
+        // still exit via stop_signal within one recv_timeout period (~100ms).
         while self
             .active_thread_counter
             .load(std::sync::atomic::Ordering::Relaxed)
             > 0
         {
-            let _ = self.worker_pool.sender.send(WorkerMessage::Close);
-            std::thread::sleep(std::time::Duration::from_micros(10));
+            let _ = self.worker_pool.sender.try_send(WorkerMessage::Close);
+            std::thread::sleep(std::time::Duration::from_millis(1));
         }
 
         // Drain again after threads are closed
@@ -798,6 +802,7 @@ impl Database {
             &db.stats,
             &PoisonDart::new(db.is_poisoned.clone()),
             &db.active_thread_counter,
+            &db.stop_signal,
         )?;
 
         log::trace!("Recovery successful");
@@ -910,6 +915,7 @@ impl Database {
             &db.stats,
             &PoisonDart::new(db.is_poisoned.clone()),
             &db.active_thread_counter,
+            &db.stop_signal,
         )?;
 
         Ok(db)

--- a/src/flush/manager.rs
+++ b/src/flush/manager.rs
@@ -12,7 +12,11 @@ pub struct FlushManager {
 
 impl FlushManager {
     pub fn new() -> Self {
-        let (tx, rx) = flume::bounded(1_000);
+        // Unbounded: flush tasks are tiny (Arc<Task>) and bounded by memtable
+        // rotation rate. A bounded channel here participated in the deadlock
+        // chain (#260) — workers blocked on flush enqueue while holding the
+        // worker channel slot needed for Close delivery.
+        let (tx, rx) = flume::unbounded();
 
         Self {
             sender: tx,

--- a/src/keyspace/mod.rs
+++ b/src/keyspace/mod.rs
@@ -747,7 +747,7 @@ impl Keyspace {
             keyspace: self.clone(),
         }));
 
-        self.worker_messager.send(WorkerMessage::Flush).ok();
+        self.worker_messager.try_send(WorkerMessage::Flush).ok();
 
         {
             // NOTE: If the difference between watermark is too large, and

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -7,7 +7,7 @@ use crate::{
     journal::manager::EvictionWatermark, poison_dart::PoisonDart, stats::Stats,
     supervisor::Supervisor, Keyspace,
 };
-use lsm_tree::{AbstractTree, MemtableId};
+use lsm_tree::{stop_signal::StopSignal, AbstractTree, MemtableId};
 use std::{
     borrow::Cow,
     sync::{atomic::AtomicUsize, Arc, Mutex},
@@ -63,16 +63,22 @@ impl WorkerPool {
         stats: &Arc<Stats>,
         poison_dart: &PoisonDart,
         thread_counter: &Arc<AtomicUsize>,
+        stop_signal: &StopSignal,
     ) -> crate::Result<()> {
         use std::sync::atomic::Ordering::Relaxed;
 
         log::debug!("Starting worker pool with {pool_size} threads");
 
-        thread_counter.fetch_add(pool_size, Relaxed);
-
         let thread_handles = (0..pool_size)
             .map(|i| {
-                std::thread::Builder::new()
+                // Increment BEFORE spawn so the counter is already visible when
+                // the worker's CounterGuard runs.  Without this, a thread that
+                // exits immediately (e.g. stop_signal already set) could
+                // decrement before the parent increments, wrapping to
+                // usize::MAX and causing drop() to wait forever.
+                thread_counter.fetch_add(1, Relaxed);
+
+                let handle = std::thread::Builder::new()
                     .name("fjall:worker".to_string())
                     .spawn({
                         log::trace!("Starting fjall worker thread #{i}");
@@ -84,33 +90,49 @@ impl WorkerPool {
                             supervisor: supervisor.clone(),
                             stats: stats.clone(),
                             sender: self.sender.clone(),
+                            stop_signal: stop_signal.clone(),
                         };
 
                         let thread_counter = thread_counter.clone();
                         let poison_dart = poison_dart.clone();
 
-                        move || loop {
-                            match worker_tick(&worker_state) {
-                                Ok(should_abort) => {
-                                    if should_abort {
-                                        log::debug!("Worker #{i} closes because DB is dropping");
-                                        thread_counter.fetch_sub(1, Relaxed);
-                                        return Ok(());
-                                    }
+                        move || {
+                            // Decrement counter on all exit paths including panic/unwind
+                            struct CounterGuard(Arc<AtomicUsize>);
+                            impl Drop for CounterGuard {
+                                fn drop(&mut self) {
+                                    self.0.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
                                 }
-                                Err(e) => {
-                                    log::error!("Worker #{i} crashed: {e:?}");
-                                    poison_dart.poison();
-                                    return Err(e);
+                            }
+                            let _guard = CounterGuard(thread_counter);
+
+                            loop {
+                                match worker_tick(&worker_state) {
+                                    Ok(should_abort) => {
+                                        if should_abort {
+                                            log::debug!(
+                                                "Worker #{i} closes because DB is dropping"
+                                            );
+                                            return Ok(());
+                                        }
+                                    }
+                                    Err(e) => {
+                                        log::error!("Worker #{i} crashed: {e:?}");
+                                        poison_dart.poison();
+                                        return Err(e);
+                                    }
                                 }
                             }
                         }
                     })
                     .inspect_err(|_| {
+                        // Roll back the counter if the thread could not be spawned.
                         thread_counter.fetch_sub(1, Relaxed);
-                    })
+                    })?;
+
+                Ok(handle)
             })
-            .collect::<Result<_, _>>()?;
+            .collect::<Result<Vec<_>, crate::Error>>()?;
 
         *self.thread_handles.lock().expect("lock is poisoned") = thread_handles;
 
@@ -125,12 +147,35 @@ struct WorkerState {
     rx: flume::Receiver<WorkerMessage>,
     sender: flume::Sender<WorkerMessage>,
     stats: Arc<Stats>,
+    stop_signal: StopSignal,
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "splitting would fragment tightly-coupled message dispatch"
+)]
 fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
-    let Ok(item) = ctx.rx.recv() else {
+    if ctx.stop_signal.is_stopped() {
         return Ok(true);
+    }
+
+    // 100ms timeout: balances stop_signal responsiveness vs idle CPU cost.
+    // Worker #0 also uses the timeout to recover dropped Flush signals.
+    let item = match ctx.rx.recv_timeout(std::time::Duration::from_millis(100)) {
+        Ok(item) => item,
+        Err(flume::RecvTimeoutError::Timeout) => {
+            // Worker #0 recovers dropped Flush signals on idle channel too
+            if ctx.worker_id == 0 && ctx.supervisor.flush_manager.len() > 0 {
+                ctx.sender.try_send(WorkerMessage::Flush).ok();
+            }
+            return Ok(false);
+        }
+        Err(flume::RecvTimeoutError::Disconnected) => return Ok(true),
     };
+
+    if ctx.stop_signal.is_stopped() {
+        return Ok(true);
+    }
 
     log::trace!("Worker #{} got message: {item:?}", ctx.worker_id);
 
@@ -219,14 +264,29 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
         WorkerMessage::Compact(keyspace) => {
             // NOTE: Let one worker prioritize flushing if there are pending flushes
             //
-            // Disable when only 1 worker exists to avoid deadlock
-            if ctx.pool_size > 1 && ctx.worker_id == 0 {
-                ctx.sender.send(WorkerMessage::Compact(keyspace)).ok();
+            // Disable when only 1 worker exists to avoid stalling/livelock: a single
+            // worker would keep re-enqueuing compaction and never actually run it.
+            // If try_send fails (channel full), fall through to run
+            // compaction here instead of dropping the work.
+            if ctx.pool_size > 1
+                && ctx.worker_id == 0
+                && ctx
+                    .sender
+                    .try_send(WorkerMessage::Compact(keyspace.clone()))
+                    .is_ok()
+            {
                 return Ok(false);
             }
 
             run_compaction(&keyspace, &ctx.supervisor.snapshot_tracker, &ctx.stats)?;
         }
+    }
+
+    // Worker #0 recovers dropped Flush signals: if flush_manager has pending
+    // tasks, re-inject one Flush. Only worker #0 does this to avoid N workers
+    // flooding the channel with redundant Flush messages under pressure.
+    if ctx.worker_id == 0 && ctx.supervisor.flush_manager.len() > 0 {
+        ctx.sender.try_send(WorkerMessage::Flush).ok();
     }
 
     Ok(false)

--- a/tests/drop_under_write_pressure.rs
+++ b/tests/drop_under_write_pressure.rs
@@ -1,0 +1,101 @@
+use fjall::{Database, KeyspaceCreateOptions};
+use std::sync::{Arc, Barrier};
+
+/// Stress test for #260: verifies that Database::drop() completes
+/// under sustained write pressure without deadlocking.
+///
+/// Uses a tiny memtable (1 KiB) to force frequent RotateMemtable/Flush/Compact
+/// messages that saturate the bounded worker channel. Spawns multiple writer
+/// threads, then drops the database while writers are active. A watchdog
+/// timeout ensures the test fails fast instead of hanging on deadlock.
+#[test]
+fn drop_completes_under_write_pressure() {
+    const WRITER_THREADS: usize = 8;
+    const ITERATIONS: usize = 5;
+    const WATCHDOG_SECS: u64 = 30;
+
+    for iteration in 0..ITERATIONS {
+        let folder = tempfile::tempdir().unwrap();
+        // Explicitly use 4 worker threads so pool_size > 1 worker #0 behavior
+        // is exercised even on single-core CI environments
+        let db = Database::builder(&folder).worker_threads(4).open().unwrap();
+        let keyspace = db
+            .keyspace("default", || {
+                KeyspaceCreateOptions::default().max_memtable_size(1_024)
+            })
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(WRITER_THREADS + 1));
+        let mut handles = Vec::new();
+
+        for t in 0..WRITER_THREADS {
+            let ks = keyspace.clone();
+            let b = barrier.clone();
+            handles.push(std::thread::spawn(move || {
+                b.wait();
+                for i in 0..10_000 {
+                    let key = format!("t{t}-k{i}");
+                    // Errors (poisoned DB, closed channel) are expected once drop starts.
+                    // We intentionally ignore them — this test validates that drop()
+                    // completes without deadlock, not write correctness.
+                    let _ = ks.insert(&key, b"value");
+                }
+            }));
+        }
+
+        // Let all writers start simultaneously
+        barrier.wait();
+
+        // Give writers a head start to fill the channel
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        // Drop the database while writers are active — this must not deadlock
+        let db_drop = std::thread::spawn(move || {
+            drop(keyspace);
+            drop(db);
+        });
+
+        // Watchdog: fail fast if drop doesn't complete within deadline
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(WATCHDOG_SECS);
+        loop {
+            if db_drop.is_finished() {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                // Don't join (would hang). Abort the process so a deadlocked drop
+                // thread cannot keep the test binary alive indefinitely.
+                eprintln!(
+                    "iteration {iteration}: drop did not complete within {WATCHDOG_SECS}s — likely deadlock; aborting process"
+                );
+                std::process::abort();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        db_drop.join().expect("drop thread panicked");
+
+        // Writers may block on backpressure inside insert(), so apply the same
+        // watchdog pattern: poll is_finished() with a deadline instead of a
+        // bare join() that could hang indefinitely.
+        for (i, h) in handles.into_iter().enumerate() {
+            // Per-thread deadline so earlier joins don't eat into later threads' budget.
+            let writer_deadline =
+                std::time::Instant::now() + std::time::Duration::from_secs(WATCHDOG_SECS);
+            loop {
+                if h.is_finished() {
+                    if let Err(e) = h.join() {
+                        panic!("iteration {iteration}: writer thread {i} panicked: {e:?}");
+                    }
+                    break;
+                }
+                if std::time::Instant::now() > writer_deadline {
+                    eprintln!(
+                        "iteration {iteration}: writer thread {i} did not complete within {WATCHDOG_SECS}s — likely stuck on backpressure; aborting process"
+                    );
+                    std::process::abort();
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace bounded channel with unbounded for flush queue to prevent `drop()` blocking when channel is full during active writes
- Add drop guard for thread counter to handle all exit paths correctly
- Limit flush recovery to worker #0 to avoid channel flooding
- Recover flush signals on idle channel timeout
- Add writer watchdog and per-spawn thread counter increment to prevent underflow races

## Test plan

- New stress test `drop_under_write_pressure` with explicit worker count and writer panic detection
- Process abort on deadlock timeout for reliable CI detection
- All existing tests pass
- Full `cargo test` green

Closes #260

Supersedes #267 (clean rebased branch — sorry about the mess in that one).