### PR TITLE
feat: add prefix_from() for seekable prefix iteration

### DIFF
--- a/src/keyspace/mod.rs
+++ b/src/keyspace/mod.rs
@@ -472,6 +472,54 @@ impl Keyspace {
         crate::iter::Iter::new(nonce, iter)
     }
 
+    /// Returns an iterator over a prefixed set of items, starting at `from`.
+    ///
+    /// The iterator yields all items whose key starts with `prefix` and is >= `from`.
+    /// This is equivalent to `prefix()` but skips keys before `from`, allowing
+    /// efficient repositioning within a prefix range without scanning from the start.
+    ///
+    /// If `from` is lexicographically before the prefix, the lower bound is clamped
+    /// to the prefix itself, so non-prefix keys are never returned. If `from` is
+    /// beyond the prefix range, the iterator is empty.
+    ///
+    /// Avoid using an empty prefix as it may scan a lot of items (unless limited).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use fjall::{Database, KeyspaceCreateOptions};
+    /// #
+    /// # let folder = tempfile::tempdir()?;
+    /// # let db = Database::builder(folder).open()?;
+    /// # let tree = db.keyspace("default", KeyspaceCreateOptions::default)?;
+    /// tree.insert("ab:1", "v1")?;
+    /// tree.insert("ab:2", "v2")?;
+    /// tree.insert("ab:3", "v3")?;
+    /// assert_eq!(2, tree.prefix_from("ab", "ab:2").count());
+    /// #
+    /// # Ok::<(), fjall::Error>(())
+    /// ```
+    pub fn prefix_from<P: AsRef<[u8]>, K: AsRef<[u8]>>(&self, prefix: P, from: K) -> Iter {
+        let prefix_bytes = prefix.as_ref();
+        let from_bytes = from.as_ref();
+        let (prefix_lower, upper) = lsm_tree::range::prefix_to_range(prefix_bytes);
+
+        // Clamp: if `from` precedes the prefix range, use the prefix's own lower
+        // bound so non-prefix keys are never yielded.  Compare raw byte slices
+        // before allocating a UserKey to avoid a wasted allocation in each branch.
+        let lower = match &prefix_lower {
+            std::ops::Bound::Included(p) if from_bytes > p.as_ref() => {
+                std::ops::Bound::Included(UserKey::from(from_bytes))
+            }
+            std::ops::Bound::Unbounded => {
+                std::ops::Bound::Included(UserKey::from(from_bytes))
+            }
+            _ => prefix_lower,
+        };
+
+        self.range((lower, upper))
+    }
+
     /// Approximates the amount of items in the keyspace.
     ///
     /// For update- or delete-heavy workloads, this value will

--- a/src/readable.rs
+++ b/src/readable.rs
@@ -298,4 +298,62 @@ pub trait Readable {
     /// # Ok::<(), fjall::Error>(())
     /// ```
     fn prefix<K: AsRef<[u8]>>(&self, keyspace: impl AsRef<Keyspace>, prefix: K) -> Iter;
+
+    /// Iterates over a prefixed set of the snapshot, starting at `from`.
+    ///
+    /// The iterator yields all items whose key starts with `prefix` and is >= `from`.
+    /// This is equivalent to `prefix()` but skips keys before `from`, allowing
+    /// efficient repositioning within a prefix range without scanning from the start.
+    ///
+    /// If `from` is lexicographically before the prefix, the lower bound is clamped
+    /// to the prefix itself, so non-prefix keys are never returned. If `from` is
+    /// beyond the prefix range, the iterator is empty.
+    ///
+    /// Avoid using an empty prefix as it may scan a lot of items (unless limited).
+    ///
+    /// The default implementation delegates to [`Readable::range`]. Implementors
+    /// that override `range()` with custom visibility logic will automatically get
+    /// correct `prefix_from` behavior.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use fjall::{Database, KeyspaceCreateOptions, Readable};
+    /// #
+    /// # let folder = tempfile::tempdir()?;
+    /// # let db = Database::builder(folder).open()?;
+    /// # let tree = db.keyspace("default", KeyspaceCreateOptions::default)?;
+    /// tree.insert("ab:1", "v1")?;
+    /// tree.insert("ab:2", "v2")?;
+    /// tree.insert("ab:3", "v3")?;
+    ///
+    /// assert_eq!(2, db.snapshot().prefix_from(&tree, "ab", "ab:2").count());
+    /// #
+    /// # Ok::<(), fjall::Error>(())
+    /// ```
+    fn prefix_from<P: AsRef<[u8]>, K: AsRef<[u8]>>(
+        &self,
+        keyspace: impl AsRef<Keyspace>,
+        prefix: P,
+        from: K,
+    ) -> Iter {
+        let prefix_bytes = prefix.as_ref();
+        let from_bytes = from.as_ref();
+        let (prefix_lower, upper) = lsm_tree::range::prefix_to_range(prefix_bytes);
+
+        // Clamp: if `from` precedes the prefix range, use the prefix's own lower
+        // bound so non-prefix keys are never yielded.  Compare raw byte slices
+        // before allocating a UserKey to avoid a wasted allocation in each branch.
+        let lower = match &prefix_lower {
+            std::ops::Bound::Included(p) if from_bytes > p.as_ref() => {
+                std::ops::Bound::Included(lsm_tree::UserKey::from(from_bytes))
+            }
+            std::ops::Bound::Unbounded => {
+                std::ops::Bound::Included(lsm_tree::UserKey::from(from_bytes))
+            }
+            _ => prefix_lower,
+        };
+
+        self.range(keyspace, (lower, upper))
+    }
 }

--- a/tests/prefix_from.rs
+++ b/tests/prefix_from.rs
@@ -1,0 +1,169 @@
+use fjall::{Database, KeyspaceCreateOptions, Readable};
+
+fn setup() -> (tempfile::TempDir, Database, fjall::Keyspace) {
+    let folder = tempfile::tempdir().unwrap();
+    let db = Database::builder(&folder).open().unwrap();
+    let tree = db
+        .keyspace("default", KeyspaceCreateOptions::default)
+        .unwrap();
+    (folder, db, tree)
+}
+
+#[test]
+fn prefix_from_happy_path() {
+    let (_dir, _db, tree) = setup();
+    tree.insert("ab:1", "v1").unwrap();
+    tree.insert("ab:2", "v2").unwrap();
+    tree.insert("ab:3", "v3").unwrap();
+    assert_eq!(2, tree.prefix_from("ab", "ab:2").count());
+}
+
+#[test]
+fn prefix_from_all_keys() {
+    let (_dir, _db, tree) = setup();
+    tree.insert("ab:1", "v1").unwrap();
+    tree.insert("ab:2", "v2").unwrap();
+    tree.insert("ab:3", "v3").unwrap();
+    // from == prefix should return all prefix keys
+    assert_eq!(3, tree.prefix_from("ab", "ab").count());
+}
+
+#[test]
+fn prefix_from_clamps_when_from_before_prefix() {
+    let (_dir, _db, tree) = setup();
+    tree.insert("aa:1", "v0").unwrap();
+    tree.insert("ab:1", "v1").unwrap();
+    tree.insert("ab:2", "v2").unwrap();
+    tree.insert("ac:1", "v3").unwrap();
+
+    // from="aa:1" is before prefix="ab", should clamp to "ab" and never yield "aa:1"
+    let keys: Vec<_> = tree
+        .prefix_from("ab", "aa:1")
+        .map(|g| {
+            let k = g.key().unwrap();
+            String::from_utf8(k.to_vec()).unwrap()
+        })
+        .collect();
+
+    assert_eq!(keys, vec!["ab:1", "ab:2"]);
+}
+
+#[test]
+fn prefix_from_empty_when_from_beyond_range() {
+    let (_dir, _db, tree) = setup();
+    tree.insert("ab:1", "v1").unwrap();
+    tree.insert("ab:2", "v2").unwrap();
+
+    // "zz" is far beyond the "ab" prefix range upper bound ("ac")
+    assert_eq!(0, tree.prefix_from("ab", "zz").count());
+}
+
+#[test]
+fn prefix_from_with_non_prefix_from_in_range() {
+    let (_dir, _db, tree) = setup();
+    tree.insert("ab:1", "v1").unwrap();
+    tree.insert("ab:5", "v2").unwrap();
+    tree.insert("ab:9", "v3").unwrap();
+
+    // from="ab:3" — doesn't match any key, but is within prefix range
+    let keys: Vec<_> = tree
+        .prefix_from("ab", "ab:3")
+        .map(|g| {
+            let k = g.key().unwrap();
+            String::from_utf8(k.to_vec()).unwrap()
+        })
+        .collect();
+
+    assert_eq!(keys, vec!["ab:5", "ab:9"]);
+}
+
+#[test]
+fn prefix_from_all_0xff_prefix() {
+    let (_dir, _db, tree) = setup();
+    let prefix = [0xFF, 0xFF];
+    let key1 = [0xFF, 0xFF, 0x01];
+    let key2 = [0xFF, 0xFF, 0x02];
+    let key3 = [0xFF, 0xFF, 0x03];
+    tree.insert(key1, "v1").unwrap();
+    tree.insert(key2, "v2").unwrap();
+    tree.insert(key3, "v3").unwrap();
+
+    // Start from key2 — should get key2 and key3
+    assert_eq!(2, tree.prefix_from(prefix, key2).count());
+}
+
+/// Snapshot-based prefix_from via Readable trait.
+#[test]
+fn prefix_from_snapshot_isolation() {
+    let (_dir, db, tree) = setup();
+    tree.insert("ab:1", "v1").unwrap();
+    tree.insert("ab:2", "v2").unwrap();
+    tree.insert("ab:3", "v3").unwrap();
+
+    let snapshot = db.snapshot();
+
+    // Insert after snapshot
+    tree.insert("ab:4", "v4").unwrap();
+
+    // Snapshot should see only 2 items from ab:2 onward (not ab:4)
+    assert_eq!(2, snapshot.prefix_from(&tree, "ab", "ab:2").count());
+}
+
+/// Empty prefix degenerates to a range scan from `from` to end of keyspace.
+#[test]
+fn prefix_from_empty_prefix() {
+    let (_dir, _db, tree) = setup();
+    tree.insert("a", "v1").unwrap();
+    tree.insert("b", "v2").unwrap();
+    tree.insert("c", "v3").unwrap();
+    tree.insert("d", "v4").unwrap();
+
+    // Empty prefix + from="b" → scan from "b" onward
+    assert_eq!(3, tree.prefix_from("", "b").count());
+}
+
+/// Reverse iteration via next_back().
+#[test]
+fn prefix_from_reverse_iteration() {
+    let (_dir, _db, tree) = setup();
+    tree.insert("ab:1", "v1").unwrap();
+    tree.insert("ab:2", "v2").unwrap();
+    tree.insert("ab:3", "v3").unwrap();
+    tree.insert("ab:4", "v4").unwrap();
+
+    let mut iter = tree.prefix_from("ab", "ab:2");
+    // Forward: first should be ab:2
+    let first = iter.next().unwrap();
+    assert_eq!(&*first.key().unwrap(), b"ab:2");
+    // Backward: last remaining should be ab:4
+    let last = iter.next_back().unwrap();
+    assert_eq!(&*last.key().unwrap(), b"ab:4");
+}
+
+/// Empty keyspace returns empty iterator.
+#[test]
+fn prefix_from_empty_keyspace() {
+    let (_dir, _db, tree) = setup();
+    assert_eq!(0, tree.prefix_from("ab", "ab:1").count());
+}
+
+/// Snapshot-based clamp behavior via Readable trait.
+#[test]
+fn prefix_from_snapshot_clamps_when_from_before_prefix() {
+    let (_dir, db, tree) = setup();
+    tree.insert("aa:1", "v0").unwrap();
+    tree.insert("ab:1", "v1").unwrap();
+    tree.insert("ab:2", "v2").unwrap();
+
+    let snapshot = db.snapshot();
+
+    let keys: Vec<_> = snapshot
+        .prefix_from(&tree, "ab", "aa:1")
+        .map(|g| {
+            let k = g.key().unwrap();
+            String::from_utf8(k.to_vec()).unwrap()
+        })
+        .collect();
+
+    assert_eq!(keys, vec!["ab:1", "ab:2"]);
+}


### PR DESCRIPTION
tl;dr:

Adds prefix_from(prefix, from) to both Keyspace and the Readable trait. This allows efficient resumption of prefix scans from an arbitrary key, avoiding O(N) skip-ahead when only a suffix of the prefix range is needed.

Implemented as a thin wrapper over range() using prefix_to_range() for the upper bound. The lower bound is clamped to max(prefix_start, from) so that callers who pass a `from` before the prefix range never receive non-prefix keys.

Includes 11 integration tests covering happy path, boundary clamping, reverse iteration, snapshot isolation, empty prefix, empty keyspace, and all-0xFF prefix edge cases.

---

# `prefix_from`: seekable prefix iteration

## What changed

Two new methods named `prefix_from` were added:

1. **`Keyspace::prefix_from(prefix, from)`** — instance method on `Keyspace`
2. **`Readable::prefix_from(keyspace, prefix, from)`** — default method on the `Readable` trait (used by snapshots and write transactions)

Both return the same `Iter` type already used by `prefix()` and `range()`.

## Why

The existing `prefix()` API iterates over every key that shares a given prefix, always starting from the first matching key. There is no way to resume iteration partway through a prefix range without scanning and discarding all earlier keys.

This matters for any workload that:

- **Paginates within a prefix** — e.g., fetching keys `ab:101` through `ab:200` out of millions of `ab:*` keys. Without `prefix_from`, the caller must call `prefix("ab")` and skip past the first 100 keys in userspace, which forces the storage engine to read, decompress, and merge-sort all of them.
- **Resumes after interruption** — a long-running scan that checkpoints its last-seen key needs to pick up where it left off.
- **Implements cursor-based access patterns** — where the next page starts at the successor of the previous page's last key.

The underlying LSM tree already supports efficient block-index seeks via `range()`. The new method simply computes the correct range bounds from the prefix and delegates, so it gets O(log N) block-level seeking rather than O(N) key scanning.

## How it works

`prefix_from` is a thin composition of two existing primitives:

1. `lsm_tree::range::prefix_to_range(prefix)` — computes both bounds for the prefix range.
2. The lower bound is clamped to `max(prefix_start, from)` so that if `from` precedes the prefix lexicographically, non-prefix keys are never yielded.
3. The resulting `(lower, upper)` range is passed to the existing `range()` method.

### Edge cases

| Input | Behavior |
|---|---|
| `from` within prefix range | Seeks to `from`, iterates within prefix (normal case) | | `from` before prefix | Clamped to prefix start — equivalent to `prefix()` | | `from` beyond prefix range | Empty iterator |
| Empty prefix | Scans from `from` to end of keyspace (same as `prefix("")` degeneracy) | | All-0xFF prefix | Upper bound is `Unbounded`; scans from `from` onward |

## Compatibility

- **Fully additive** — no existing APIs or types are changed.
- **Default trait method** — implementors of `Readable` get `prefix_from` for free; no breaking changes to downstream trait implementations.
- **Doc-tested** — both methods include runnable examples that are exercised by `cargo test`.
- **Integration-tested** — 8 tests covering happy path, boundary clamping, empty results, snapshot isolation, and 0xFF prefixes.