### PR TITLE
fix stalls: defer journal rotation fsyncs to outside the writer lock

### DIFF
--- a/src/db_test.rs
+++ b/src/db_test.rs
@@ -24,7 +24,7 @@ fn clear_recover_sealed() -> crate::Result<()> {
         db.supervisor
             .journal
             .get_writer()
-            .rotate_no_fsync()?
+            .start_rotation()?
             .0
             .persist()?;
 

--- a/src/db_test.rs
+++ b/src/db_test.rs
@@ -21,7 +21,12 @@ fn clear_recover_sealed() -> crate::Result<()> {
 
         tree.rotate_memtable_and_wait()?;
         assert!(tree.is_empty()?);
-        db.supervisor.journal.get_writer().rotate()?;
+        db.supervisor
+            .journal
+            .get_writer()
+            .rotate_no_fsync()?
+            .0
+            .persist()?;
 
         tree.insert("b", "a")?;
         assert!(tree.contains_key("b")?);

--- a/src/journal/manager.rs
+++ b/src/journal/manager.rs
@@ -178,7 +178,7 @@ impl JournalManager {
     ) -> crate::Result<DeferredSync> {
         let journal_size = journal_writer.len()?;
 
-        let (deferred, sealed_path) = journal_writer.rotate_no_fsync()?;
+        let (deferred, sealed_path) = journal_writer.start_rotation()?;
 
         self.enqueue(Item {
             path: sealed_path,

--- a/src/journal/manager.rs
+++ b/src/journal/manager.rs
@@ -2,7 +2,7 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
-use super::writer::Writer;
+use super::writer::{DeferredSync, Writer};
 use crate::Keyspace;
 use lsm_tree::{AbstractTree, SeqNo};
 use std::{path::PathBuf, sync::MutexGuard};
@@ -168,23 +168,24 @@ impl JournalManager {
 
     /// Seals the current journal and enqueues it for eviction tracking.
     ///
-    /// IMPORTANT: this function uses `rotate_no_fsync` which doesn't fsync the directory nor the old journal. It's the
-    /// responsibility of the caller to sync both!
+    /// Returns a [`DeferredSync`] that must be persisted by the caller (outside the journal lock).
+    /// The new active writer also holds a clone of it and will resolve it on its next
+    /// [`PersistMode::SyncData`] or [`PersistMode::SyncAll`] call, whichever comes first.
     pub(crate) fn rotate_journal(
         &mut self,
         journal_writer: &mut MutexGuard<Writer>,
         watermarks: Vec<EvictionWatermark>,
-    ) -> crate::Result<(Writer, PathBuf)> {
+    ) -> crate::Result<DeferredSync> {
         let journal_size = journal_writer.len()?;
 
-        let (sealed, folder) = journal_writer.rotate_no_fsync()?;
+        let (deferred, sealed_path) = journal_writer.rotate_no_fsync()?;
 
         self.enqueue(Item {
-            path: sealed.path.clone(),
+            path: sealed_path,
             watermarks,
             size_in_bytes: journal_size,
         });
 
-        Ok((sealed, folder))
+        Ok(deferred)
     }
 }

--- a/src/journal/manager.rs
+++ b/src/journal/manager.rs
@@ -166,21 +166,25 @@ impl JournalManager {
         }
     }
 
+    /// Seals the current journal and enqueues it for eviction tracking.
+    ///
+    /// IMPORTANT: this function uses `rotate_no_fsync` which doesn't fsync the directory nor the old journal. It's the
+    /// responsibility of the caller to sync both!
     pub(crate) fn rotate_journal(
         &mut self,
         journal_writer: &mut MutexGuard<Writer>,
         watermarks: Vec<EvictionWatermark>,
-    ) -> crate::Result<()> {
+    ) -> crate::Result<(Writer, PathBuf)> {
         let journal_size = journal_writer.len()?;
 
-        let (sealed_path, _) = journal_writer.rotate()?;
+        let (sealed, folder) = journal_writer.rotate_no_fsync()?;
 
         self.enqueue(Item {
-            path: sealed_path,
+            path: sealed.path.clone(),
             watermarks,
             size_in_bytes: journal_size,
         });
 
-        Ok(())
+        Ok((sealed, folder))
     }
 }

--- a/src/journal/test.rs
+++ b/src/journal/test.rs
@@ -45,7 +45,7 @@ fn journal_rotation() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.start_rotation()?.0.persist()?;
+        writer.rotate()?;
     }
 
     assert!(path.try_exists()?);
@@ -81,7 +81,7 @@ fn journal_recovery_active() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.start_rotation()?.0.persist()?;
+        writer.rotate()?;
 
         writer.write_batch(
             [
@@ -92,7 +92,7 @@ fn journal_recovery_active() -> crate::Result<()> {
             2,
             1,
         )?;
-        writer.start_rotation()?.0.persist()?;
+        writer.rotate()?;
 
         writer.write_batch(
             [
@@ -144,7 +144,7 @@ fn journal_recovery_active_lz4() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.start_rotation()?.0.persist()?;
+        writer.rotate()?;
 
         writer.write_batch(
             [
@@ -155,7 +155,7 @@ fn journal_recovery_active_lz4() -> crate::Result<()> {
             2,
             1,
         )?;
-        writer.start_rotation()?.0.persist()?;
+        writer.rotate()?;
 
         writer.write_batch(
             [
@@ -205,7 +205,7 @@ fn journal_recovery_no_active() -> crate::Result<()> {
                 2,
                 0,
             )?;
-            writer.start_rotation()?.0.persist()?;
+            writer.rotate()?;
         }
 
         // NOTE: Delete the new, active journal -> old journal will be

--- a/src/journal/test.rs
+++ b/src/journal/test.rs
@@ -45,7 +45,7 @@ fn journal_rotation() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.rotate()?;
+        writer.rotate_no_fsync()?.0.persist()?;
     }
 
     assert!(path.try_exists()?);
@@ -81,7 +81,7 @@ fn journal_recovery_active() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.rotate()?;
+        writer.rotate_no_fsync()?.0.persist()?;
 
         writer.write_batch(
             [
@@ -92,7 +92,7 @@ fn journal_recovery_active() -> crate::Result<()> {
             2,
             1,
         )?;
-        writer.rotate()?;
+        writer.rotate_no_fsync()?.0.persist()?;
 
         writer.write_batch(
             [
@@ -144,7 +144,7 @@ fn journal_recovery_active_lz4() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.rotate()?;
+        writer.rotate_no_fsync()?.0.persist()?;
 
         writer.write_batch(
             [
@@ -155,7 +155,7 @@ fn journal_recovery_active_lz4() -> crate::Result<()> {
             2,
             1,
         )?;
-        writer.rotate()?;
+        writer.rotate_no_fsync()?.0.persist()?;
 
         writer.write_batch(
             [
@@ -205,7 +205,7 @@ fn journal_recovery_no_active() -> crate::Result<()> {
                 2,
                 0,
             )?;
-            writer.rotate()?;
+            writer.rotate_no_fsync()?.0.persist()?;
         }
 
         // NOTE: Delete the new, active journal -> old journal will be

--- a/src/journal/test.rs
+++ b/src/journal/test.rs
@@ -45,7 +45,7 @@ fn journal_rotation() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.rotate_no_fsync()?.0.persist()?;
+        writer.start_rotation()?.0.persist()?;
     }
 
     assert!(path.try_exists()?);
@@ -81,7 +81,7 @@ fn journal_recovery_active() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.rotate_no_fsync()?.0.persist()?;
+        writer.start_rotation()?.0.persist()?;
 
         writer.write_batch(
             [
@@ -92,7 +92,7 @@ fn journal_recovery_active() -> crate::Result<()> {
             2,
             1,
         )?;
-        writer.rotate_no_fsync()?.0.persist()?;
+        writer.start_rotation()?.0.persist()?;
 
         writer.write_batch(
             [
@@ -144,7 +144,7 @@ fn journal_recovery_active_lz4() -> crate::Result<()> {
             2,
             0,
         )?;
-        writer.rotate_no_fsync()?.0.persist()?;
+        writer.start_rotation()?.0.persist()?;
 
         writer.write_batch(
             [
@@ -155,7 +155,7 @@ fn journal_recovery_active_lz4() -> crate::Result<()> {
             2,
             1,
         )?;
-        writer.rotate_no_fsync()?.0.persist()?;
+        writer.start_rotation()?.0.persist()?;
 
         writer.write_batch(
             [
@@ -205,7 +205,7 @@ fn journal_recovery_no_active() -> crate::Result<()> {
                 2,
                 0,
             )?;
-            writer.rotate_no_fsync()?.0.persist()?;
+            writer.start_rotation()?.0.persist()?;
         }
 
         // NOTE: Delete the new, active journal -> old journal will be

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -4,7 +4,8 @@
 
 use super::entry::{serialize_marker_item, Entry};
 use crate::{
-    batch::item::Item as BatchItem, journal::recovery::JournalId, keyspace::InternalKeyspaceId,
+    batch::item::Item as BatchItem, file::fsync_directory, journal::recovery::JournalId,
+    keyspace::InternalKeyspaceId,
 };
 use lsm_tree::{CompressionType, SeqNo, ValueType};
 use std::{
@@ -12,6 +13,7 @@ use std::{
     hash::Hasher,
     io::{BufWriter, Seek, Write},
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 
 // TODO: this should be a database configuration
@@ -19,11 +21,52 @@ pub const PRE_ALLOCATED_BYTES: u64 = 64 * 1_024 * 1_024;
 
 pub const JOURNAL_BUFFER_BYTES: usize = 8 * 1_024;
 
+struct DeferredSyncState {
+    folder: PathBuf,
+    sealed: Writer,
+}
+
+/// Wraps the two fsyncs that must happen after a journal rotation
+/// (directory fsync + sealed journal fsync). Shared between the new
+/// journal writer and the worker pool via [`Arc`]. Whichever side calls
+/// [`DeferredSync::persist`] first does the actual work; the other is a no-op.
+#[derive(Clone)]
+pub(crate) struct DeferredSync {
+    inner: Arc<Mutex<Option<DeferredSyncState>>>,
+}
+
+impl DeferredSync {
+    fn new(folder: PathBuf, sealed: Writer) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Some(DeferredSyncState { folder, sealed }))),
+        }
+    }
+
+    /// Performs the deferred fsyncs (directory + sealed journal).
+    /// Safe to call concurrently and multiple times. Only the first call does something.
+    pub(crate) fn persist(&self) -> std::io::Result<()> {
+        #[expect(clippy::expect_used)]
+        let mut guard = self.inner.lock().expect("lock is poisoned");
+
+        let Some(mut state) = guard.take() else {
+            return Ok(());
+        };
+
+        fsync_directory(&state.folder)?;
+        state.sealed.persist(PersistMode::SyncAll)?;
+
+        Ok(())
+    }
+}
+
 pub struct Writer {
     pub(crate) path: PathBuf,
     file: BufWriter<File>,
     buf: Vec<u8>,
     is_buffer_dirty: bool,
+
+    /// Deferred sync obligations from a recent journal rotation.
+    pub(crate) deferred_sync: Option<DeferredSync>,
 
     compression: CompressionType,
     compression_threshold: usize,
@@ -62,12 +105,20 @@ impl Writer {
         Ok(self.file.get_ref().metadata()?.len())
     }
 
-    /// Creates the next journal file inline, swaps `self` to it, and returns the old journal.
+    /// Creates the next journal file inline, swaps `self` to it, and returns a [`DeferredSync`]
+    /// (shared with `self.deferred_sync`) and the sealed journal's path.
     ///
-    /// IMPORTANT: this function doesn't fsync the directory nor the old journal. It's the
-    /// responsibility of the caller to sync both!
-    /// We split it out so that we can sync it without holding the journal writer lock.
-    pub(crate) fn rotate_no_fsync(&mut self) -> crate::Result<(Writer, PathBuf)> {
+    /// The caller must call [`DeferredSync::persist`] outside the journal lock. The new writer
+    /// also holds a clone and will resolve it on its next [`PersistMode::SyncData`] or
+    /// [`PersistMode::SyncAll`] call, whichever comes first.
+    pub(crate) fn rotate_no_fsync(&mut self) -> crate::Result<(DeferredSync, PathBuf)> {
+        // Resolve any pending deferred sync from a prior rotation before creating a new one.
+        // This ensures an unresolved sync is not silently dropped when self.deferred_sync is
+        // overwritten below.
+        if let Some(deferred) = self.deferred_sync.take() {
+            deferred.persist()?;
+        }
+
         // Flush write buffer to kernel (no fsync, that's the caller's job).
         self.persist(PersistMode::Buffer)?;
 
@@ -115,11 +166,16 @@ impl Writer {
 
         let comp = self.compression;
         let compt = self.compression_threshold;
-        let mut old = Self::create_new(new_path)?;
-        old.set_compression(comp, compt);
-        std::mem::swap(self, &mut old);
+        let mut swapped = Self::create_new(new_path)?;
+        swapped.set_compression(comp, compt);
+        // Make `self` the new active writer.
+        std::mem::swap(self, &mut swapped);
 
-        Ok((old, folder))
+        let sealed_path = swapped.path.clone();
+        let deferred = DeferredSync::new(folder, swapped);
+        self.deferred_sync = Some(deferred.clone());
+
+        Ok((deferred, sealed_path))
     }
 
     pub fn create_new<P: Into<PathBuf>>(path: P) -> crate::Result<Self> {
@@ -145,6 +201,7 @@ impl Writer {
             file: BufWriter::new(file),
             buf: Vec::new(),
             is_buffer_dirty: false,
+            deferred_sync: None,
             compression: CompressionType::None,
             compression_threshold: 0,
         })
@@ -178,6 +235,7 @@ impl Writer {
                 file: BufWriter::with_capacity(JOURNAL_BUFFER_BYTES, file),
                 buf: Vec::new(),
                 is_buffer_dirty: false,
+                deferred_sync: None,
                 compression: CompressionType::None,
                 compression_threshold: 0,
             });
@@ -195,6 +253,7 @@ impl Writer {
             file: BufWriter::with_capacity(JOURNAL_BUFFER_BYTES, file),
             buf: Vec::new(),
             is_buffer_dirty: false,
+            deferred_sync: None,
             compression: CompressionType::None,
             compression_threshold: 0,
         })
@@ -215,6 +274,14 @@ impl Writer {
                 );
             })?;
             self.is_buffer_dirty = false;
+        }
+
+        // Resolve any deferred rotation sync obligations before fsyncing this journal,
+        // so a Sync* caller gets a true end-to-end durability guarantee.
+        if matches!(mode, PersistMode::SyncData | PersistMode::SyncAll) {
+            if let Some(deferred) = self.deferred_sync.take() {
+                deferred.persist()?;
+            }
         }
 
         match mode {

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -4,8 +4,7 @@
 
 use super::entry::{serialize_marker_item, Entry};
 use crate::{
-    batch::item::Item as BatchItem, file::fsync_directory, journal::recovery::JournalId,
-    keyspace::InternalKeyspaceId,
+    batch::item::Item as BatchItem, journal::recovery::JournalId, keyspace::InternalKeyspaceId,
 };
 use lsm_tree::{CompressionType, SeqNo, ValueType};
 use std::{
@@ -63,8 +62,14 @@ impl Writer {
         Ok(self.file.get_ref().metadata()?.len())
     }
 
-    pub fn rotate(&mut self) -> crate::Result<(PathBuf, PathBuf)> {
-        self.persist(PersistMode::SyncAll)?;
+    /// Creates the next journal file inline, swaps `self` to it, and returns the old journal.
+    ///
+    /// IMPORTANT: this function doesn't fsync the directory nor the old journal. It's the
+    /// responsibility of the caller to sync both!
+    /// We split it out so that we can sync it without holding the journal writer lock.
+    pub(crate) fn rotate_no_fsync(&mut self) -> crate::Result<(Writer, PathBuf)> {
+        // Flush write buffer to kernel (no fsync, that's the caller's job).
+        self.persist(PersistMode::Buffer)?;
 
         log::debug!(
             "Sealing active journal at {}, len={}B",
@@ -79,8 +84,6 @@ impl Writer {
                 })?
                 .len(),
         );
-
-        let prev_path = self.path.clone();
 
         let folder = self
             .path
@@ -112,13 +115,11 @@ impl Writer {
 
         let comp = self.compression;
         let compt = self.compression_threshold;
-        *self = Self::create_new(new_path.clone())?;
-        self.set_compression(comp, compt);
+        let mut old = Self::create_new(new_path)?;
+        old.set_compression(comp, compt);
+        std::mem::swap(self, &mut old);
 
-        // IMPORTANT: fsync folder on Unix
-        fsync_directory(&folder)?;
-
-        Ok((prev_path, new_path))
+        Ok((old, folder))
     }
 
     pub fn create_new<P: Into<PathBuf>>(path: P) -> crate::Result<Self> {

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -112,6 +112,13 @@ impl Writer {
     /// The caller must call [`DeferredSync::persist`] outside the journal lock. The new writer
     /// also holds a clone and will resolve it on its next [`PersistMode::SyncData`] or
     /// [`PersistMode::SyncAll`] call, whichever comes first.
+    #[cfg(test)]
+    pub(crate) fn rotate(&mut self) -> crate::Result<PathBuf> {
+        let (deferred, path) = self.start_rotation()?;
+        deferred.persist()?;
+        Ok(path)
+    }
+
     pub(crate) fn start_rotation(&mut self) -> crate::Result<(DeferredSync, PathBuf)> {
         // Resolve any pending deferred sync from a prior rotation before creating a new one.
         // This ensures an unresolved sync is not silently dropped when self.deferred_sync is

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -112,7 +112,7 @@ impl Writer {
     /// The caller must call [`DeferredSync::persist`] outside the journal lock. The new writer
     /// also holds a clone and will resolve it on its next [`PersistMode::SyncData`] or
     /// [`PersistMode::SyncAll`] call, whichever comes first.
-    pub(crate) fn rotate_no_fsync(&mut self) -> crate::Result<(DeferredSync, PathBuf)> {
+    pub(crate) fn start_rotation(&mut self) -> crate::Result<(DeferredSync, PathBuf)> {
         // Resolve any pending deferred sync from a prior rotation before creating a new one.
         // This ensures an unresolved sync is not silently dropped when self.deferred_sync is
         // overwritten below.

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -48,12 +48,13 @@ impl DeferredSync {
         #[expect(clippy::expect_used)]
         let mut guard = self.inner.lock().expect("lock is poisoned");
 
-        let Some(mut state) = guard.take() else {
+        let Some(state) = guard.as_mut() else {
             return Ok(());
         };
 
         fsync_directory(&state.folder)?;
         state.sealed.persist(PersistMode::SyncAll)?;
+        guard.take();
 
         Ok(())
     }
@@ -115,8 +116,9 @@ impl Writer {
         // Resolve any pending deferred sync from a prior rotation before creating a new one.
         // This ensures an unresolved sync is not silently dropped when self.deferred_sync is
         // overwritten below.
-        if let Some(deferred) = self.deferred_sync.take() {
+        if let Some(deferred) = self.deferred_sync.clone() {
             deferred.persist()?;
+            self.deferred_sync = None;
         }
 
         // Flush write buffer to kernel (no fsync, that's the caller's job).
@@ -279,8 +281,9 @@ impl Writer {
         // Resolve any deferred rotation sync obligations before fsyncing this journal,
         // so a Sync* caller gets a true end-to-end durability guarantee.
         if matches!(mode, PersistMode::SyncData | PersistMode::SyncAll) {
-            if let Some(deferred) = self.deferred_sync.take() {
+            if let Some(deferred) = self.deferred_sync.clone() {
                 deferred.persist()?;
+                self.deferred_sync = None;
             }
         }
 

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -173,15 +173,14 @@ impl Writer {
         let new_path = folder.join(format!("{}.jnl", journal_id + 1));
         log::debug!("Rotating active journal to {}", new_path.display());
 
-        let comp = self.compression;
-        let compt = self.compression_threshold;
-        let mut swapped = Self::create_new(new_path)?;
-        swapped.set_compression(comp, compt);
-        // Make `self` the new active writer.
-        std::mem::swap(self, &mut swapped);
+        let old_journal = {
+          let mut new_journal = Self::create_new(new_path)?;
+          new_journal.set_compression(self.compression, self.compression_threshold);
+          std::mem::replace(self, new_journal)
+        };
 
-        let sealed_path = swapped.path.clone();
-        let deferred = DeferredSync::new(folder, swapped);
+        let sealed_path = old_journal.path.clone();
+        let deferred = DeferredSync::new(folder, old_journal);
         self.deferred_sync = Some(deferred.clone());
 
         Ok((deferred, sealed_path))

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -174,9 +174,9 @@ impl Writer {
         log::debug!("Rotating active journal to {}", new_path.display());
 
         let old_journal = {
-          let mut new_journal = Self::create_new(new_path)?;
-          new_journal.set_compression(self.compression, self.compression_threshold);
-          std::mem::replace(self, new_journal)
+            let mut new_journal = Self::create_new(new_path)?;
+            new_journal.set_compression(self.compression, self.compression_threshold);
+            std::mem::replace(self, new_journal)
         };
 
         let sealed_path = old_journal.path.clone();

--- a/src/journal/writer.rs
+++ b/src/journal/writer.rs
@@ -123,6 +123,9 @@ impl Writer {
         // Resolve any pending deferred sync from a prior rotation before creating a new one.
         // This ensures an unresolved sync is not silently dropped when self.deferred_sync is
         // overwritten below.
+        //
+        // We purposefully clone the guard and only set it to `None` if the persist is actually successful,
+        // otherwise we may remove sync barrier even though it failed.
         if let Some(deferred) = self.deferred_sync.clone() {
             deferred.persist()?;
             self.deferred_sync = None;

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -195,7 +195,7 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
                     deferred.persist()?;
 
                     for keyspace in stragglers {
-                        log::info!("Rotating {:?} to try to reduce journal size", keyspace.name,);
+                        log::info!("Rotating {:?} to try to reduce journal size", keyspace.name);
                         keyspace.request_rotation();
                     }
                 }

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -3,10 +3,9 @@
 // (found in the LICENSE-* files in the repository)
 
 use crate::{
-    compaction::worker::run as run_compaction, file::fsync_directory,
-    flush::worker::run as run_flush, journal::manager::EvictionWatermark,
-    journal::writer::PersistMode, poison_dart::PoisonDart, stats::Stats, supervisor::Supervisor,
-    Keyspace,
+    compaction::worker::run as run_compaction, flush::worker::run as run_flush,
+    journal::manager::EvictionWatermark, poison_dart::PoisonDart, stats::Stats,
+    supervisor::Supervisor, Keyspace,
 };
 use lsm_tree::{AbstractTree, MemtableId};
 use std::{
@@ -179,7 +178,7 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
                         seqnos
                     };
 
-                    let (mut sealed, folder) =
+                    let deferred =
                         journal_manager.rotate_journal(&mut journal_writer, seqno_map)?;
                     drop(journal_writer);
 
@@ -193,9 +192,7 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
                     drop(journal_manager);
 
                     // Sync the directory changes and the old journal outside the lock.
-                    // Do both before run_flush() reads the sealed file below.
-                    fsync_directory(&folder)?;
-                    sealed.persist(PersistMode::SyncAll)?;
+                    deferred.persist()?;
 
                     for keyspace in stragglers {
                         log::info!("Rotating {:?} to try to reduce journal size", keyspace.name,);

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -3,9 +3,10 @@
 // (found in the LICENSE-* files in the repository)
 
 use crate::{
-    compaction::worker::run as run_compaction, flush::worker::run as run_flush,
-    journal::manager::EvictionWatermark, poison_dart::PoisonDart, stats::Stats,
-    supervisor::Supervisor, Keyspace,
+    compaction::worker::run as run_compaction, file::fsync_directory,
+    flush::worker::run as run_flush, journal::manager::EvictionWatermark,
+    journal::writer::PersistMode, poison_dart::PoisonDart, stats::Stats, supervisor::Supervisor,
+    Keyspace,
 };
 use lsm_tree::{AbstractTree, MemtableId};
 use std::{
@@ -178,21 +179,27 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
                         seqnos
                     };
 
-                    journal_manager.rotate_journal(&mut journal_writer, seqno_map)?;
+                    let (mut sealed, folder) =
+                        journal_manager.rotate_journal(&mut journal_writer, seqno_map)?;
+                    drop(journal_writer);
 
-                    if journal_manager.disk_space_used()
+                    let stragglers = if journal_manager.disk_space_used()
                         >= ctx.supervisor.db_config.max_journaling_size_in_bytes
                     {
-                        let stragglers =
-                            journal_manager.get_keyspaces_to_flush_for_oldest_journal_eviction();
+                        journal_manager.get_keyspaces_to_flush_for_oldest_journal_eviction()
+                    } else {
+                        Vec::new()
+                    };
+                    drop(journal_manager);
 
-                        for keyspace in stragglers {
-                            log::info!(
-                                "Rotating {:?} to try to reduce journal size",
-                                keyspace.name,
-                            );
-                            keyspace.request_rotation();
-                        }
+                    // Sync the directory changes and the old journal outside the lock.
+                    // Do both before run_flush() reads the sealed file below.
+                    fsync_directory(&folder)?;
+                    sealed.persist(PersistMode::SyncAll)?;
+
+                    for keyspace in stragglers {
+                        log::info!("Rotating {:?} to try to reduce journal size", keyspace.name,);
+                        keyspace.request_rotation();
                     }
                 }
             }


### PR DESCRIPTION
During journal rotation the flush worker was holding the journal writer mutex across two fsyncs (old-file sync_all, fsync_directory), causing persist() callers and batch writers to stall.

These two fsyncs can safely happen after the lock is released and the new writer can start being used immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Journal rotation now defers on-disk durability so persistence happens after locks are released, reducing lock hold time and improving concurrent throughput; rotation now returns a deferred handle that callers persist once locks are dropped.
  * Eviction/rotation flow updated to compute work outside locks and persist deferred durability before proceeding, improving stability under load.

* **Tests**
  * Updated rotation and recovery tests to match the deferred-persistence behavior and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->