### PR TITLE
Make the openable trait public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub use {
 };
 
 pub use tx::single_writer::{
-    SingleWriterTxKeyspace, TxDatabase as SingleWriterTxDatabase,
+    Openable, SingleWriterTxKeyspace, TxDatabase as SingleWriterTxDatabase,
     WriteTransaction as SingleWriterWriteTx,
 };
 


### PR DESCRIPTION
Hey!

That's a small PR to make the `Openable` trait public.
This would help me return a `DatabaseBuilder<Self>` in fiole [here](https://github.com/irevoire/fiole/blob/c860018587150d2893a71e9fd4280e15260c90ee/src/database.rs#L15-L22).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public API to include additional transaction-related functionality, providing new capabilities for integration and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->