### PR TITLE
fix #296

### DIFF
--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -105,7 +105,7 @@ impl WriteBatch {
         }
 
         log::trace!("batch: Acquiring journal writer");
-        let mut journal_writer = self.db.supervisor.journal.get_writer();
+        let mut journal_writer = self.db.supervisor.journal.get_writer()?;
 
         // IMPORTANT: Check the poisoned flag after getting journal mutex, otherwise TOCTOU
         if self.db.is_poisoned.load(Ordering::Relaxed) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -288,7 +288,7 @@ impl Database {
     /// Returns the disk space usage of the journal.
     #[doc(hidden)]
     pub fn journal_disk_space(&self) -> crate::Result<u64> {
-        Ok(self.supervisor.journal.get_writer().len()?
+        Ok(self.supervisor.journal.get_writer()?.len()?
             + self
                 .supervisor
                 .journal_manager
@@ -587,7 +587,7 @@ impl Database {
         log::debug!("journal recovery result: {journal_recovery:#?}");
 
         let active_journal = Arc::new(journal_recovery.active);
-        active_journal.get_writer().persist(PersistMode::SyncAll)?;
+        active_journal.get_writer()?.persist(PersistMode::SyncAll)?;
 
         let sealed_journals = journal_recovery.sealed;
 

--- a/src/db_test.rs
+++ b/src/db_test.rs
@@ -21,7 +21,7 @@ fn clear_recover_sealed() -> crate::Result<()> {
 
         tree.rotate_memtable_and_wait()?;
         assert!(tree.is_empty()?);
-        db.supervisor.journal.get_writer().rotate()?;
+        db.supervisor.journal.get_writer()?.rotate()?;
 
         tree.insert("b", "a")?;
         assert!(tree.contains_key("b")?);

--- a/src/journal/mod.rs
+++ b/src/journal/mod.rs
@@ -31,7 +31,13 @@ pub struct Journal {
 
 impl std::fmt::Debug for Journal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.path().display())
+        write!(
+            f,
+            "{}",
+            self.path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| String::from("<failed to read path>"))
+        )
     }
 }
 
@@ -94,24 +100,27 @@ impl Journal {
         })
     }
 
-    /// Hands out write access for the journal.
-    pub(crate) fn get_writer(&self) -> MutexGuard<'_, Writer> {
-        #[expect(clippy::expect_used)]
-        self.writer.lock().expect("lock is poisoned")
+    /// Hands out write access to the journal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the journal writer is poisoned.
+    pub(crate) fn get_writer(&self) -> crate::Result<MutexGuard<'_, Writer>> {
+        self.writer.lock().map_err(|_| crate::Error::Poisoned)
     }
 
-    pub fn path(&self) -> PathBuf {
-        self.get_writer().path.clone()
+    pub fn path(&self) -> crate::Result<PathBuf> {
+        Ok(self.get_writer()?.path.clone())
     }
 
     pub fn get_reader(&self) -> crate::Result<JournalBatchReader> {
-        let raw_reader = JournalReader::new(self.path())?;
+        let raw_reader = JournalReader::new(self.path()?)?;
         Ok(JournalBatchReader::new(raw_reader))
     }
 
     /// Persists the journal.
     pub fn persist(&self, mode: PersistMode) -> crate::Result<()> {
-        let mut journal_writer = self.get_writer();
+        let mut journal_writer = self.get_writer()?;
         journal_writer.persist(mode).map_err(Into::into)
     }
 

--- a/src/journal/test.rs
+++ b/src/journal/test.rs
@@ -34,7 +34,7 @@ fn journal_rotation() -> crate::Result<()> {
 
     {
         let journal = Journal::create_new(&path)?;
-        let mut writer = journal.get_writer();
+        let mut writer = journal.get_writer()?;
 
         writer.write_batch(
             [
@@ -70,7 +70,7 @@ fn journal_recovery_active() -> crate::Result<()> {
 
     {
         let journal = Journal::create_new(&path)?;
-        let mut writer = journal.get_writer();
+        let mut writer = journal.get_writer()?;
 
         writer.write_batch(
             [
@@ -110,7 +110,7 @@ fn journal_recovery_active() -> crate::Result<()> {
     assert!(next_next_path.try_exists()?);
 
     let journal_recovered = Journal::recover(dir2, CompressionType::None, 0)?;
-    assert_eq!(journal_recovered.active.path(), next_next_path);
+    assert_eq!(journal_recovered.active.path()?, next_next_path);
     assert_eq!(journal_recovered.sealed, &[(0, path), (1, next_path)]);
 
     Ok(())
@@ -133,7 +133,7 @@ fn journal_recovery_active_lz4() -> crate::Result<()> {
 
     {
         let journal = Journal::create_new(&path)?.with_compression(CompressionType::Lz4, 1);
-        let mut writer = journal.get_writer();
+        let mut writer = journal.get_writer()?;
 
         writer.write_batch(
             [
@@ -173,7 +173,7 @@ fn journal_recovery_active_lz4() -> crate::Result<()> {
     assert!(next_next_path.try_exists()?);
 
     let journal_recovered = Journal::recover(dir2, CompressionType::None, 0)?;
-    assert_eq!(journal_recovered.active.path(), next_next_path);
+    assert_eq!(journal_recovered.active.path()?, next_next_path);
     assert_eq!(journal_recovered.sealed, &[(0, path), (1, next_path)]);
 
     Ok(())
@@ -194,7 +194,7 @@ fn journal_recovery_no_active() -> crate::Result<()> {
         let journal = Journal::create_new(&path)?;
 
         {
-            let mut writer = journal.get_writer();
+            let mut writer = journal.get_writer()?;
 
             writer.write_batch(
                 [
@@ -217,7 +217,7 @@ fn journal_recovery_no_active() -> crate::Result<()> {
     assert!(!next_path.try_exists()?);
 
     let journal_recovered = Journal::recover(dir2, CompressionType::None, 0)?;
-    assert_eq!(journal_recovered.active.path(), path);
+    assert_eq!(journal_recovered.active.path()?, path);
     assert_eq!(journal_recovered.sealed, &[]);
 
     Ok(())
@@ -241,7 +241,7 @@ fn journal_truncation_corrupt_bytes() -> crate::Result<()> {
     {
         let journal = Journal::create_new(&path)?;
         journal
-            .get_writer()
+            .get_writer()?
             .write_batch(values.iter(), values.len(), 0)?;
     }
 
@@ -301,7 +301,7 @@ fn journal_truncation_repeating_start_marker() -> crate::Result<()> {
     {
         let journal = Journal::create_new(&path)?;
         journal
-            .get_writer()
+            .get_writer()?
             .write_batch(values.iter(), values.len(), 0)?;
     }
 
@@ -369,7 +369,7 @@ fn journal_truncation_repeating_end_marker() -> crate::Result<()> {
     {
         let journal = Journal::create_new(&path)?;
         journal
-            .get_writer()
+            .get_writer()?
             .write_batch(values.iter(), values.len(), 0)?;
     }
 
@@ -429,7 +429,7 @@ fn journal_truncation_repeating_item_marker() -> crate::Result<()> {
     {
         let journal = Journal::create_new(&path)?;
         journal
-            .get_writer()
+            .get_writer()?
             .write_batch(values.iter(), values.len(), 0)?;
     }
 

--- a/src/keyspace/mod.rs
+++ b/src/keyspace/mod.rs
@@ -236,7 +236,7 @@ impl Keyspace {
     pub fn clear(&self) -> crate::Result<()> {
         use std::sync::atomic::Ordering;
 
-        let mut journal_writer = self.supervisor.journal.get_writer();
+        let mut journal_writer = self.supervisor.journal.get_writer()?;
 
         // IMPORTANT: Check the poisoned flag after getting journal mutex, otherwise TOCTOU
         if self.is_poisoned.load(Ordering::Relaxed) {
@@ -719,7 +719,7 @@ impl Keyspace {
     #[doc(hidden)]
     pub fn rotate_memtable(&self) -> crate::Result<bool> {
         log::trace!("acquiring journal lock");
-        let journal_writer = self.supervisor.journal.get_writer();
+        let journal_writer = self.supervisor.journal.get_writer()?;
         let active_memtable_id = self.tree.active_memtable().id();
         self.inner_rotate_memtable(journal_writer, active_memtable_id)
     }
@@ -916,7 +916,7 @@ impl Keyspace {
         let key = key.into();
         let value = value.into();
 
-        let mut journal_writer = self.supervisor.journal.get_writer();
+        let mut journal_writer = self.supervisor.journal.get_writer()?;
 
         // IMPORTANT: Check the poisoned flag after getting journal mutex, otherwise TOCTOU
         if self.is_poisoned.load(Ordering::Relaxed) {
@@ -987,7 +987,7 @@ impl Keyspace {
 
         let key = key.into();
 
-        let mut journal_writer = self.supervisor.journal.get_writer();
+        let mut journal_writer = self.supervisor.journal.get_writer()?;
 
         // IMPORTANT: Check the poisoned flag after getting journal mutex, otherwise TOCTOU
         if self.is_poisoned.load(Ordering::Relaxed) {
@@ -1070,7 +1070,7 @@ impl Keyspace {
 
         let key = key.into();
 
-        let mut journal_writer = self.supervisor.journal.get_writer();
+        let mut journal_writer = self.supervisor.journal.get_writer()?;
 
         // IMPORTANT: Check the poisoned flag after getting journal mutex, otherwise TOCTOU
         if self.is_poisoned.load(Ordering::Relaxed) {

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -140,7 +140,7 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
         }
         WorkerMessage::RotateMemtable(keyspace, memtable_id) => {
             log::trace!("acquiring journal lock");
-            let journal_writer = keyspace.supervisor.journal.get_writer();
+            let journal_writer = keyspace.supervisor.journal.get_writer()?;
             keyspace.inner_rotate_memtable(journal_writer, memtable_id)?;
         }
         WorkerMessage::Flush => {
@@ -150,7 +150,7 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
 
             {
                 log::trace!("acquiring journal lock to maybe rotate journal");
-                let mut journal_writer = ctx.supervisor.journal.get_writer();
+                let mut journal_writer = ctx.supervisor.journal.get_writer()?;
 
                 if journal_writer.pos()? > 64_000_000 {
                     #[expect(clippy::expect_used)]


### PR DESCRIPTION
fixes #296 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error propagation across journal operations, including journal writer acquisition, persistence during recovery, and batch commit handling, so failures surface reliably instead of being potentially suppressed.

* **Breaking Changes**
  * Journal-related operations now surface errors for previously infallible journal path and writer access, requiring callers to handle additional failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->