### PR TITLE
refactor: structural hot-path cleanups for journal eviction and batch commit

### DIFF
--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -7,7 +7,6 @@ pub mod item;
 use crate::{Database, Keyspace, PersistMode};
 use item::Item;
 use lsm_tree::{AbstractTree, UserKey, UserValue, ValueType};
-use std::collections::HashSet;
 
 /// An atomic write batch
 ///
@@ -128,9 +127,9 @@ impl WriteBatch {
             }
         }
 
-        // TODO: maybe we can use a stack alloc hashset/vec here, such as smallset
-        #[expect(clippy::mutable_key_type)]
-        let mut keyspaces_with_possible_stall = HashSet::new();
+        // NOTE: Typically only a handful of keyspaces are touched per batch, so a
+        // linear-dedup Vec avoids the per-commit heap allocation + hashing of a HashSet.
+        let mut keyspaces_with_possible_stall: Vec<Keyspace> = Vec::new();
 
         let mut batch_size = 0u64;
 
@@ -148,7 +147,9 @@ impl WriteBatch {
             batch_size += item_size;
 
             // IMPORTANT: Clone the handle, because we don't want to keep the keyspaces lock open
-            keyspaces_with_possible_stall.insert(item.keyspace.clone());
+            if !keyspaces_with_possible_stall.contains(&item.keyspace) {
+                keyspaces_with_possible_stall.push(item.keyspace.clone());
+            }
         }
 
         self.db.supervisor.snapshot_tracker.publish(batch_seqno);

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -132,14 +132,6 @@ impl WriteBatch {
         #[expect(clippy::mutable_key_type)]
         let mut keyspaces_with_possible_stall = HashSet::new();
 
-        #[expect(clippy::expect_used)]
-        let keyspaces = self
-            .db
-            .supervisor
-            .keyspaces
-            .read()
-            .expect("lock is poisoned");
-
         let mut batch_size = 0u64;
 
         log::trace!("Applying batch (size={}) to memtable(s)", self.data.len());
@@ -164,8 +156,6 @@ impl WriteBatch {
         drop(journal_writer);
 
         log::trace!("batch: Freed journal writer");
-
-        drop(keyspaces);
 
         // IMPORTANT: Add batch size to current write buffer size
         // Otherwise write buffer growth is unbounded when using batches

--- a/src/journal/manager.rs
+++ b/src/journal/manager.rs
@@ -5,7 +5,7 @@
 use super::writer::Writer;
 use crate::Keyspace;
 use lsm_tree::{AbstractTree, SeqNo};
-use std::{path::PathBuf, sync::MutexGuard};
+use std::{collections::VecDeque, path::PathBuf, sync::MutexGuard};
 
 /// Stores the highest seqno of a keyspace found in a journal.
 #[derive(Clone)]
@@ -42,7 +42,7 @@ impl std::fmt::Debug for Item {
 #[expect(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub struct JournalManager {
-    items: Vec<Item>,
+    items: VecDeque<Item>,
     disk_space_in_bytes: u64,
 }
 
@@ -61,7 +61,7 @@ impl JournalManager {
         crate::drop::increment_drop_counter();
 
         Self {
-            items: Vec::with_capacity(10),
+            items: VecDeque::with_capacity(10),
             disk_space_in_bytes: 0,
         }
     }
@@ -72,7 +72,7 @@ impl JournalManager {
 
     pub(crate) fn enqueue(&mut self, item: Item) {
         self.disk_space_in_bytes = self.disk_space_in_bytes.saturating_add(item.size_in_bytes);
-        self.items.push(item);
+        self.items.push_back(item);
     }
 
     /// Returns the number of journals
@@ -95,7 +95,7 @@ impl JournalManager {
     pub(crate) fn get_keyspaces_to_flush_for_oldest_journal_eviction(&self) -> Vec<Keyspace> {
         let mut items = vec![];
 
-        if let Some(item) = self.items.first() {
+        if let Some(item) = self.items.front() {
             for item in &item.watermarks {
                 let Some(partition_seqno) = item.keyspace.tree.get_highest_persisted_seqno() else {
                     items.push(item.keyspace.clone());
@@ -116,7 +116,7 @@ impl JournalManager {
         log::debug!("Running journal maintenance");
 
         loop {
-            let Some(item) = self.items.first() else {
+            let Some(item) = self.items.front() else {
                 return Ok(());
             };
 
@@ -162,7 +162,7 @@ impl JournalManager {
             })?;
 
             self.disk_space_in_bytes = self.disk_space_in_bytes.saturating_sub(item.size_in_bytes);
-            self.items.remove(0);
+            self.items.pop_front();
         }
     }
 

--- a/src/journal/manager.rs
+++ b/src/journal/manager.rs
@@ -184,3 +184,124 @@ impl JournalManager {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use test_log::test;
+
+    /// Builds a sealed-journal item backed by a real (empty) file on disk.
+    ///
+    /// `watermarks` is left empty so `maintenance` treats the journal as fully
+    /// flushed and evicts it without needing a live keyspace.
+    fn make_item(dir: &std::path::Path, id: u64, size_in_bytes: u64) -> Item {
+        let path = dir.join(format!("{id}.jnl"));
+        std::fs::File::create(&path).unwrap();
+        Item {
+            path,
+            size_in_bytes,
+            watermarks: vec![],
+        }
+    }
+
+    #[test]
+    fn journal_manager_enqueue_is_fifo_and_accounts_disk_space() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut manager = JournalManager::new();
+        assert_eq!(0, manager.sealed_journal_count());
+        assert_eq!(0, manager.disk_space_used());
+
+        manager.enqueue(make_item(dir.path(), 1, 100));
+        manager.enqueue(make_item(dir.path(), 2, 200));
+        manager.enqueue(make_item(dir.path(), 3, 300));
+
+        assert_eq!(3, manager.sealed_journal_count());
+        // active journal is not tracked here, so journal_count == sealed + 1
+        assert_eq!(4, manager.journal_count());
+        assert_eq!(600, manager.disk_space_used());
+
+        // FIFO invariant: the oldest enqueued journal is at the front.
+        // `maintenance` relies on this to evict from oldest to newest.
+        let order: Vec<_> = manager
+            .items
+            .iter()
+            .map(|i| i.path.file_name().unwrap().to_owned())
+            .collect();
+        assert_eq!(
+            vec![
+                std::ffi::OsString::from("1.jnl"),
+                std::ffi::OsString::from("2.jnl"),
+                std::ffi::OsString::from("3.jnl"),
+            ],
+            order,
+        );
+    }
+
+    #[test]
+    fn journal_manager_maintenance_evicts_all_fully_flushed_journals() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut manager = JournalManager::new();
+        let paths: Vec<_> = (1..=3)
+            .map(|id| {
+                let item = make_item(dir.path(), id, 100);
+                let path = item.path.clone();
+                manager.enqueue(item);
+                path
+            })
+            .collect();
+
+        assert_eq!(3, manager.sealed_journal_count());
+        assert_eq!(300, manager.disk_space_used());
+        for path in &paths {
+            assert!(path.try_exists().unwrap());
+        }
+
+        // With empty watermarks every journal counts as fully flushed, so all
+        // are evicted (front to back) and their files deleted from disk.
+        manager.maintenance().unwrap();
+
+        assert_eq!(0, manager.sealed_journal_count());
+        assert_eq!(0, manager.disk_space_used());
+        for path in &paths {
+            assert!(!path.try_exists().unwrap());
+        }
+    }
+
+    #[test]
+    fn journal_manager_clear_drops_items_without_touching_disk() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut manager = JournalManager::new();
+        let item = make_item(dir.path(), 1, 100);
+        let path = item.path.clone();
+        manager.enqueue(item);
+        assert_eq!(1, manager.sealed_journal_count());
+
+        manager.clear();
+
+        assert_eq!(0, manager.sealed_journal_count());
+        // clear only drops the in-memory queue; the file is left for recovery.
+        assert!(path.try_exists().unwrap());
+    }
+
+    #[test]
+    fn journal_manager_oldest_eviction_candidates_reads_front() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut manager = JournalManager::new();
+        // Empty queue: nothing to flush.
+        assert!(manager
+            .get_keyspaces_to_flush_for_oldest_journal_eviction()
+            .is_empty());
+
+        // With a sealed journal present (and no watermarks), the oldest journal
+        // has no keyspaces blocking its eviction, so the candidate list is empty.
+        manager.enqueue(make_item(dir.path(), 1, 100));
+        assert!(manager
+            .get_keyspaces_to_flush_for_oldest_journal_eviction()
+            .is_empty());
+    }
+}

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -68,3 +68,102 @@ fn batch_multi_keys() -> fjall::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn batch_multi_keyspace_commits_atomically() -> fjall::Result<()> {
+    let folder = tempfile::tempdir()?;
+
+    let db = Database::builder(&folder).open()?;
+    let ks_a = db.keyspace("a", KeyspaceCreateOptions::default)?;
+    let ks_b = db.keyspace("b", KeyspaceCreateOptions::default)?;
+    let ks_c = db.keyspace("c", KeyspaceCreateOptions::default)?;
+
+    let mut batch = db.batch();
+
+    // Interleave keyspaces and repeatedly touch the same keyspace within the
+    // batch: exercises the linear-dedup stall set (one keyspace appears many
+    // times) and the apply loop running without the keyspaces read-lock.
+    batch.insert(&ks_a, "1", "a1");
+    batch.insert(&ks_b, "1", "b1");
+    batch.insert(&ks_a, "2", "a2");
+    batch.insert(&ks_c, "1", "c1");
+    batch.insert(&ks_a, "3", "a3");
+    batch.insert(&ks_b, "2", "b2");
+
+    // Nothing is visible until commit.
+    assert_eq!(ks_a.len()?, 0);
+    assert_eq!(ks_b.len()?, 0);
+    assert_eq!(ks_c.len()?, 0);
+
+    batch.commit()?;
+
+    assert_eq!(ks_a.len()?, 3);
+    assert_eq!(ks_b.len()?, 2);
+    assert_eq!(ks_c.len()?, 1);
+
+    assert_eq!(&*ks_a.get("1")?.unwrap(), b"a1");
+    assert_eq!(&*ks_a.get("2")?.unwrap(), b"a2");
+    assert_eq!(&*ks_a.get("3")?.unwrap(), b"a3");
+    assert_eq!(&*ks_b.get("1")?.unwrap(), b"b1");
+    assert_eq!(&*ks_b.get("2")?.unwrap(), b"b2");
+    assert_eq!(&*ks_c.get("1")?.unwrap(), b"c1");
+
+    Ok(())
+}
+
+#[test]
+fn batch_commit_concurrent_with_keyspace_creation() -> fjall::Result<()> {
+    let folder = tempfile::tempdir()?;
+
+    let db = Database::builder(&folder).open()?;
+    let tree = db.keyspace("default", KeyspaceCreateOptions::default)?;
+
+    // A second thread creates keyspaces (which takes keyspaces.write()) while
+    // the main thread commits batches (which used to hold keyspaces.read()
+    // across its apply loop). This guards against a deadlock or lost writes
+    // after dropping that read-lock.
+    //
+    // A barrier releases both threads together so the keyspace creation
+    // deterministically overlaps the commit loop, actually exercising the
+    // contention path rather than relying on scheduling luck.
+    let start = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+    let creator = std::thread::spawn({
+        let db = db.clone();
+        let start = std::sync::Arc::clone(&start);
+        move || -> fjall::Result<()> {
+            start.wait();
+            for i in 0..50 {
+                let ks = db.keyspace(&format!("ks_{i}"), KeyspaceCreateOptions::default)?;
+                ks.insert("k", "v")?;
+            }
+            Ok(())
+        }
+    });
+
+    start.wait();
+    for i in 0..200 {
+        let mut batch = db.batch();
+        batch.insert(&tree, format!("key-{i}"), format!("val-{i}"));
+        batch.commit()?;
+    }
+
+    creator.join().expect("creator thread should not panic")?;
+
+    // Every batched write landed.
+    assert_eq!(tree.len()?, 200);
+    for i in 0..200 {
+        assert_eq!(
+            &*tree.get(format!("key-{i}"))?.unwrap(),
+            format!("val-{i}").as_bytes(),
+        );
+    }
+
+    // Every concurrently-created keyspace is intact.
+    for i in 0..50 {
+        let ks = db.keyspace(&format!("ks_{i}"), KeyspaceCreateOptions::default)?;
+        assert_eq!(&*ks.get("k")?.unwrap(), b"v");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Three small, self-contained **structural refactors** on the write/maintenance hot paths, plus validation tests. No new dependencies, no on-disk format changes, no public API changes. All three are behavior-preserving changes to in-memory data structures and lock scope.

> **TL;DR on perf:** I benchmarked these (see the Benchmarks section). The data-structure changes show clear differences in isolation, but **end-to-end batch-commit throughput is within noise** at realistic scale — the commit path is dominated by journal writes + memtable inserts, not these micro-structures. So the honest pitch is "correct structural cleanups that don't regress, with a small measurable win in the single-keyspace batch case," not "big speedup." One change even has a tradeoff (noted below).

## Changes

### 1. `Vec` -> `VecDeque` for O(1) sealed-journal eviction
`JournalManager::maintenance()` evicts fully-flushed sealed journals with `Vec::remove(0)` inside a loop, shifting the entire `Vec` on every eviction (O(n) per eviction). Switched the backing store to `VecDeque` (`push_back` / `front` / `pop_front`). FIFO order — which `maintenance()` depends on to flush oldest-to-newest — is unchanged.

*Honesty note:* the sealed-journal list is typically only a handful of items, so the real-world impact is negligible (see N=16 row below). The asymptotic win only shows up at pathological queue lengths that shouldn't occur in practice. The value is using the right data structure for a FIFO queue.

### 2. Drop stale `keyspaces` read-lock held across the memtable apply loop
`WriteBatch::commit` held `supervisor.keyspaces.read()` across the entire apply loop. That guard became dead weight once batch items started carrying their own `Arc<Keyspace>` handles (in `27bba77`): the loop reads `item.keyspace.tree` and never touches the keyspaces map. Holding it needlessly blocked the flush worker's `keyspaces.write()` (journal rotation) for the duration of a batch. Lock acquisition order is unchanged everywhere (`journal_writer -> keyspaces`), so removing it introduces no inversion.

*Honesty note:* the primary justification is that the lock is dead code. Any throughput benefit (shorter contention window vs. the flush worker) is workload-dependent and was within noise in my benchmarks.

### 3. Dedup stall-check set with `Vec` instead of `HashSet`
The post-commit stall-check set is populated then iterated, never probed for membership. `Keyspace` is `Eq`/`Hash` by name only, so a `Vec` with a linear `contains()`-guard dedups correctly while avoiding a per-commit heap allocation + hashing for the common case of a handful of keyspaces. Also removes the now-unneeded `mutable_key_type` lint allowance and the `HashSet` import.

*Honesty note / tradeoff:* the `Vec` + linear `contains()` is faster for the common small case but **O(M*K)**, so it becomes *slower* than `HashSet` once a single batch touches many distinct keyspaces (crossover around ~64 distinct keyspaces in my microbench). For typical batches (a handful of keyspaces) it's a net win and removes an allocation; if large-fan-out batches are a concern, this one is worth scrutinizing or reverting.

## Benchmarks

Machine: Intel Core Ultra 9 285H, `rustc 1.95.0`, `--release`/`opt-level=3`. Microbenchmarks are best-of-N (to cut scheduler noise); end-to-end is repeated raw runs. These are not criterion-grade statistics — directional, reproducible, honest. Harness code is available on request (dependency-free, `std::time` + `black_box`); I left it out of the PR to keep the diff focused, but happy to add it under `benches/` if you'd like it committed.

**Isolated: journal eviction drain (`Vec::remove(0)` vs `VecDeque::pop_front`)**

| N (queue len) | Vec (us) | VecDeque (us) | speedup |
|--------------:|---------:|--------------:|--------:|
| 16 (realistic) | 0.461 | 0.399 | 1.16x |
| 256 | 22.96 | 8.03 | 2.86x |
| 1024 | 167.3 | 22.1 | 7.58x |
| 16384 (pathological) | 78138 | 644 | 121x |

Real queue length is ~handful, so this is the N=16 row: a sub-microsecond, negligible difference. The big numbers are purely asymptotic.

**Isolated: stall-set dedup+iterate (`HashSet` vs `Vec`), M items / K distinct keyspaces**

| M / K | HashSet (us) | Vec (us) | speedup |
|------:|-------------:|---------:|--------:|
| 4 / 1 | 0.117 | 0.067 | 1.75x |
| 16 / 4 | 0.458 | 0.273 | 1.68x |
| 64 / 8 | 1.827 | 1.166 | 1.57x |
| 256 / 16 | 7.05 | 5.06 | 1.39x |
| 1000 / 64 | 28.3 | 50.6 | **0.56x** (Vec slower) |

Confirms both the common-case win and the large-fan-out regression called out above.

**End-to-end: batch-commit throughput via public API (before = `main`, after = this branch)**

| Scenario | before (commits/s) | after (commits/s) | verdict |
|----------|-------------------:|------------------:|---------|
| A: single-thread, 1 keyspace, 8 items/batch | ~281k–283k | ~289k–301k | small, consistent ~5% gain |
| B: single-thread, 6 keyspaces, 12 items/batch | ~204k–207k | ~199k–210k | within noise |
| C: 4 concurrent committers | ~137k–144k | ~127k–209k | too noisy to conclude |

Net: no regression; a small win in the single-keyspace case (consistent with removing the per-commit `HashSet` allocation). Not a dramatic speedup, and I'm not claiming one.

## Commits

| Commit | Change |
|--------|--------|
| `perf(journal): use VecDeque for O(1) sealed-journal eviction` | Change 1 |
| `perf(batch): drop stale keyspaces read-lock held across memtable apply` | Change 2 |
| `perf(batch): dedup stall-check set with Vec to avoid per-commit HashSet` | Change 3 |
| `test: cover journal eviction ordering and batch multi-keyspace commit` | Tests |

Each commit is atomic and compiles + tests green on its own. (Commit messages keep the `perf(...)` prefix; given the benchmarks above, `refactor(...)` may be more honest — happy to reword if you prefer.)

## Tests

- New inline test module for `JournalManager` (none existed): FIFO enqueue order, disk-space accounting, that `maintenance()` evicts all fully-flushed journals and deletes their files, that `clear()` drops only in-memory entries (leaving files for recovery), and that `get_keyspaces_to_flush_for_oldest_journal_eviction()` reads the queue front.
- `tests/batch.rs`: a multi-keyspace + repeated-keyspace batch (exercises the `Vec` dedup), and a batch-commit-concurrent-with-keyspace-creation test (guards the dropped read-lock against deadlock / lost writes; uses a `Barrier` so the keyspace-creation and commit loops deterministically overlap).

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy` clean on changed files
- Full suite green (`cargo test --features lz4`): 198 passed, 0 failed; 81 doctests passed
- All feature permutations build (`--no-default-features`, default, `lz4`, `bytes_1`, `metrics`); whitebox tests pass
- **Backward compatibility:** v1/v2 on-disk fixture loaders and all recovery tests pass — no journal serialization, recovery, or version-marker code touched
- MSRV 1.90.0 compatible

## Out of scope (deferred)

Intentionally not included, as these are architectural rather than structural: group commit for the journal mutex, snapshot-tracker GC-lock redesign, and the per-rotation all-keyspace version-history walk.

## AI assistance disclosure

**This PR was implemented with heavy AI assistance.** I'm disclosing that up front so you can apply whatever additional scrutiny you feel is warranted — please verify correctness rather than assume it. I'm happy to revise, split, or drop any part of this. The reasoning behind each change (and the git-history justification for the lock removal in change 2) is summarized above to make review easier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated batch commit tracking to more accurately determine which keyspaces are affected during a transaction, improving stall/halt handling.
  * Refined journal eviction behavior by switching the sealed-journal queue to FIFO deque semantics, keeping disk-space accounting consistent.
* **Tests**
  * Added coverage for atomic multi-keyspace batch commits and correct results with interleaved updates.
  * Added concurrency tests ensuring batch commits remain correct while keyspaces are created in parallel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
