### PR TITLE
Check L0 after recovery

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -792,18 +792,16 @@ impl Database {
                     }));
 
                 keyspace.worker_messager.send(WorkerMessage::Flush).ok();
-            } else {
-                if keyspace.tree.l0_run_count() > 0 {
-                    log::debug!(
-                        "Queuing keyspace {:?} to maybe get compacted because L0 runs > 0",
-                        keyspace.name(),
-                    );
+            } else if keyspace.tree.l0_run_count() > 0 {
+                log::debug!(
+                    "Queuing keyspace {:?} to maybe get compacted because L0 runs > 0",
+                    keyspace.name(),
+                );
 
-                    keyspace
-                        .worker_messager
-                        .send(WorkerMessage::Compact(keyspace.clone()))
-                        .ok();
-                }
+                keyspace
+                    .worker_messager
+                    .send(WorkerMessage::Compact(keyspace.clone()))
+                    .ok();
             }
         }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -779,7 +779,10 @@ impl Database {
             .values()
         {
             if keyspace.tree.sealed_memtable_count() > 0 {
-                log::trace!("Queuing keyspace {:?} to get flushed", keyspace.name());
+                log::debug!(
+                    "Queuing keyspace {:?} to get flushed because sealed memtables > 0",
+                    keyspace.name(),
+                );
 
                 // IMPORTANT: Add task to flush manager, so it can be flushed
                 db.supervisor
@@ -789,6 +792,18 @@ impl Database {
                     }));
 
                 keyspace.worker_messager.send(WorkerMessage::Flush).ok();
+            } else {
+                if keyspace.tree.l0_run_count() > 0 {
+                    log::debug!(
+                        "Queuing keyspace {:?} to maybe get compacted because L0 runs > 0",
+                        keyspace.name(),
+                    );
+
+                    keyspace
+                        .worker_messager
+                        .send(WorkerMessage::Compact(keyspace.clone()))
+                        .ok();
+                }
             }
         }
 

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -231,3 +231,52 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
 
     Ok(false)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AbstractTree, Database, KeyspaceCreateOptions};
+    use test_log::test;
+
+    // https://github.com/fjall-rs/fjall/pull/303
+    #[test]
+    fn keyspace_compact_after_startup() -> crate::Result<()> {
+        let folder = tempfile::tempdir()?;
+
+        {
+            let db = Database::builder(&folder).open()?;
+
+            let ks = db.keyspace("default", KeyspaceCreateOptions::default)?;
+
+            ks.insert("a", "a")?;
+            ks.rotate_memtable_and_wait()?;
+
+            ks.insert("a", "a")?;
+            ks.rotate_memtable_and_wait()?;
+
+            ks.insert("a", "a")?;
+            ks.rotate_memtable_and_wait()?;
+
+            assert!(ks.tree.l0_run_count() > 0);
+        }
+
+        {
+            let db = Database::builder(&folder)
+                .worker_threads_unchecked(0)
+                .open()?;
+
+            assert_eq!(
+                1,
+                db.worker_pool.rx.len(),
+                "worker message should be enqueued on startup",
+            );
+            let item = db.worker_pool.rx.try_recv().expect("should get message");
+            assert!(
+                matches!(item, WorkerMessage::Compact(_)),
+                "worker message should be compaction request",
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/tests/keyspace_clear.rs
+++ b/tests/keyspace_clear.rs
@@ -1,7 +1,7 @@
+use fjall::{Database, KeyspaceCreateOptions};
+
 #[test_log::test]
 fn clear_recover() -> fjall::Result<()> {
-    use fjall::{Database, KeyspaceCreateOptions};
-
     let folder = tempfile::tempdir()?;
 
     {
@@ -30,8 +30,6 @@ fn clear_recover() -> fjall::Result<()> {
 
 #[test_log::test]
 fn clear_recover_multi_tree() -> fjall::Result<()> {
-    use fjall::{Database, KeyspaceCreateOptions};
-
     let folder = tempfile::tempdir()?;
 
     {


### PR DESCRIPTION
to maybe start compacting in case we recover a database that crashed midway through a L0->L1 compaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database recovery scheduling so pending flushes and compactions resume correctly.
  * Added more detailed recovery logging to better diagnose maintenance task scheduling.
* **Tests**
  * Added a startup recovery test that verifies a compaction request is queued when appropriate.
* **Chores**
  * Cleaned up test imports in keyspace-clear tests without changing test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->