### PR TITLE
fix: release the active thread slot when a worker exits abnormally

### DIFF
--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -88,19 +88,29 @@ impl WorkerPool {
                         let thread_counter = thread_counter.clone();
                         let poison_dart = poison_dart.clone();
 
-                        move || loop {
-                            match worker_tick(&worker_state) {
-                                Ok(should_abort) => {
-                                    if should_abort {
-                                        log::debug!("Worker #{i} closes because DB is dropping");
-                                        thread_counter.fetch_sub(1, Relaxed);
-                                        return Ok(());
+                        move || {
+                            // The counter must drop on *every* way out of this
+                            // thread, not just the graceful one: `Database::drop`
+                            // spins on it (`while counter > 0`), so a worker that
+                            // returns an error or unwinds would keep the database
+                            // closing forever.
+                            let _counter_guard = ActiveThreadGuard(thread_counter);
+
+                            loop {
+                                match worker_tick(&worker_state) {
+                                    Ok(should_abort) => {
+                                        if should_abort {
+                                            log::debug!(
+                                                "Worker #{i} closes because DB is dropping"
+                                            );
+                                            return Ok(());
+                                        }
                                     }
-                                }
-                                Err(e) => {
-                                    log::error!("Worker #{i} crashed: {e:?}");
-                                    poison_dart.poison();
-                                    return Err(e);
+                                    Err(e) => {
+                                        log::error!("Worker #{i} crashed: {e:?}");
+                                        poison_dart.poison();
+                                        return Err(e);
+                                    }
                                 }
                             }
                         }
@@ -114,6 +124,19 @@ impl WorkerPool {
         *self.thread_handles.lock().expect("lock is poisoned") = thread_handles;
 
         Ok(())
+    }
+}
+
+/// Decrements the pool's active thread counter when a worker thread leaves,
+/// whatever the reason: graceful close, error return or unwinding panic.
+///
+/// `DatabaseInner::drop` waits for this counter to reach zero, so a leaked
+/// increment makes closing the database hang forever.
+struct ActiveThreadGuard(Arc<AtomicUsize>);
+
+impl Drop for ActiveThreadGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -266,5 +289,48 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    /// A worker leaving normally releases its slot in the counter.
+    #[test]
+    fn active_thread_guard_decrements_on_scope_exit() {
+        let counter = Arc::new(AtomicUsize::new(1));
+        {
+            let _guard = ActiveThreadGuard(counter.clone());
+            assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 1);
+        }
+        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    /// A worker that returns an error releases its slot too: `Database::drop`
+    /// spins until the counter reaches zero, so a leaked slot would hang the
+    /// close forever.
+    #[test]
+    fn active_thread_guard_decrements_on_early_return() {
+        let counter = Arc::new(AtomicUsize::new(1));
+
+        fn failing_worker(counter: Arc<AtomicUsize>) -> Result<(), ()> {
+            let _guard = ActiveThreadGuard(counter);
+            Err(())
+        }
+
+        assert!(failing_worker(counter.clone()).is_err());
+        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    /// A panicking worker releases its slot as well.
+    #[test]
+    fn active_thread_guard_decrements_on_panic() {
+        let counter = Arc::new(AtomicUsize::new(1));
+        let counter_in_thread = counter.clone();
+
+        let outcome = std::thread::spawn(move || {
+            let _guard = ActiveThreadGuard(counter_in_thread);
+            panic!("worker crashed");
+        })
+        .join();
+
+        assert!(outcome.is_err());
+        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 }

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -122,7 +122,7 @@ impl WorkerPool {
 /// Claims one slot in the active thread counter per worker, immediately before
 /// that worker is spawned, and hands the slot straight back if the spawn fails.
 ///
-/// Claiming the whole pool up front would leak the slots of the workers a failed
+/// Claiming the whole pool up front would leak the slots of the workers that failed
 /// spawn never reaches: nothing ever decrements them, because those threads do
 /// not exist, and `DatabaseInner::drop` waits for the counter to reach zero.
 ///

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -9,7 +9,10 @@ use crate::{
 use lsm_tree::MemtableId;
 use std::{
     borrow::Cow,
-    sync::{atomic::AtomicUsize, Arc, Mutex},
+    sync::{
+        atomic::{AtomicUsize, Ordering::Relaxed},
+        Arc, Mutex,
+    },
     thread::JoinHandle,
 };
 
@@ -63,68 +66,82 @@ impl WorkerPool {
         poison_dart: &PoisonDart,
         thread_counter: &Arc<AtomicUsize>,
     ) -> crate::Result<()> {
-        use std::sync::atomic::Ordering::Relaxed;
-
         log::debug!("Starting worker pool with {pool_size} threads");
 
-        thread_counter.fetch_add(pool_size, Relaxed);
+        let thread_handles = claim_and_spawn(pool_size, thread_counter, |i| {
+            std::thread::Builder::new()
+                .name("fjall:worker".to_string())
+                .spawn({
+                    log::trace!("Starting fjall worker thread #{i}");
 
-        let thread_handles = (0..pool_size)
-            .map(|i| {
-                std::thread::Builder::new()
-                    .name("fjall:worker".to_string())
-                    .spawn({
-                        log::trace!("Starting fjall worker thread #{i}");
+                    let worker_state = WorkerState {
+                        pool_size,
+                        worker_id: i,
+                        rx: self.rx.clone(),
+                        supervisor: supervisor.clone(),
+                        stats: stats.clone(),
+                        sender: self.sender.clone(),
+                    };
 
-                        let worker_state = WorkerState {
-                            pool_size,
-                            worker_id: i,
-                            rx: self.rx.clone(),
-                            supervisor: supervisor.clone(),
-                            stats: stats.clone(),
-                            sender: self.sender.clone(),
-                        };
+                    let thread_counter = thread_counter.clone();
+                    let poison_dart = poison_dart.clone();
 
-                        let thread_counter = thread_counter.clone();
-                        let poison_dart = poison_dart.clone();
+                    move || {
+                        // The counter must drop on *every* way out of this
+                        // thread, not just the graceful one: `Database::drop`
+                        // spins on it (`while counter > 0`), so a worker that
+                        // returns an error or unwinds would keep the database
+                        // closing forever.
+                        let _counter_guard = ActiveThreadGuard(thread_counter);
 
-                        move || {
-                            // The counter must drop on *every* way out of this
-                            // thread, not just the graceful one: `Database::drop`
-                            // spins on it (`while counter > 0`), so a worker that
-                            // returns an error or unwinds would keep the database
-                            // closing forever.
-                            let _counter_guard = ActiveThreadGuard(thread_counter);
-
-                            loop {
-                                match worker_tick(&worker_state) {
-                                    Ok(should_abort) => {
-                                        if should_abort {
-                                            log::debug!(
-                                                "Worker #{i} closes because DB is dropping"
-                                            );
-                                            return Ok(());
-                                        }
+                        loop {
+                            match worker_tick(&worker_state) {
+                                Ok(should_abort) => {
+                                    if should_abort {
+                                        log::debug!("Worker #{i} closes because DB is dropping");
+                                        return Ok(());
                                     }
-                                    Err(e) => {
-                                        log::error!("Worker #{i} crashed: {e:?}");
-                                        poison_dart.poison();
-                                        return Err(e);
-                                    }
+                                }
+                                Err(e) => {
+                                    log::error!("Worker #{i} crashed: {e:?}");
+                                    poison_dart.poison();
+                                    return Err(e);
                                 }
                             }
                         }
-                    })
-                    .inspect_err(|_| {
-                        thread_counter.fetch_sub(1, Relaxed);
-                    })
-            })
-            .collect::<Result<_, _>>()?;
+                    }
+                })
+        })?;
 
         *self.thread_handles.lock().expect("lock is poisoned") = thread_handles;
 
         Ok(())
     }
+}
+
+/// Claims one slot in the active thread counter per worker, immediately before
+/// that worker is spawned, and hands the slot straight back if the spawn fails.
+///
+/// Claiming the whole pool up front would leak the slots of the workers a failed
+/// spawn never reaches: nothing ever decrements them, because those threads do
+/// not exist, and `DatabaseInner::drop` waits for the counter to reach zero.
+///
+/// The spawn is a parameter so the failure path can be tested without having to
+/// exhaust the operating system's thread limit.
+fn claim_and_spawn<H, S: FnMut(usize) -> std::io::Result<H>>(
+    pool_size: usize,
+    thread_counter: &Arc<AtomicUsize>,
+    mut spawn: S,
+) -> std::io::Result<Vec<H>> {
+    (0..pool_size)
+        .map(|i| {
+            thread_counter.fetch_add(1, Relaxed);
+
+            spawn(i).inspect_err(|_| {
+                thread_counter.fetch_sub(1, Relaxed);
+            })
+        })
+        .collect()
 }
 
 /// Decrements the pool's active thread counter when a worker thread leaves,
@@ -136,7 +153,7 @@ struct ActiveThreadGuard(Arc<AtomicUsize>);
 
 impl Drop for ActiveThreadGuard {
     fn drop(&mut self) {
-        self.0.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        self.0.fetch_sub(1, Relaxed);
     }
 }
 
@@ -291,15 +308,51 @@ mod tests {
         Ok(())
     }
 
+    /// Every worker that is actually spawned holds exactly one slot.
+    #[test]
+    fn claim_and_spawn_claims_one_slot_per_worker() {
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let handles = claim_and_spawn(3, &counter, |i| Ok::<_, std::io::Error>(i))
+            .expect("all spawns succeed");
+
+        assert_eq!(handles, vec![0, 1, 2]);
+        assert_eq!(counter.load(Relaxed), 3);
+    }
+
+    /// A failed spawn releases its own slot and never claims one for the workers
+    /// it did not get to. `DatabaseInner::drop` spins until the counter reaches
+    /// zero, so a slot held by a thread that does not exist hangs the close
+    /// forever.
+    #[test]
+    fn claim_and_spawn_counts_live_workers_only() {
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let result = claim_and_spawn(4, &counter, |i| {
+            if i == 2 {
+                Err(std::io::Error::other("cannot spawn thread"))
+            } else {
+                Ok(i)
+            }
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            counter.load(Relaxed),
+            2,
+            "only the two workers that started should hold a slot",
+        );
+    }
+
     /// A worker leaving normally releases its slot in the counter.
     #[test]
     fn active_thread_guard_decrements_on_scope_exit() {
         let counter = Arc::new(AtomicUsize::new(1));
         {
             let _guard = ActiveThreadGuard(counter.clone());
-            assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 1);
+            assert_eq!(counter.load(Relaxed), 1);
         }
-        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
+        assert_eq!(counter.load(Relaxed), 0);
     }
 
     /// A worker that returns an error releases its slot too: `Database::drop`
@@ -315,7 +368,7 @@ mod tests {
         }
 
         assert!(failing_worker(counter.clone()).is_err());
-        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
+        assert_eq!(counter.load(Relaxed), 0);
     }
 
     /// A panicking worker releases its slot as well.
@@ -331,6 +384,6 @@ mod tests {
         .join();
 
         assert!(outcome.is_err());
-        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
+        assert_eq!(counter.load(Relaxed), 0);
     }
 }


### PR DESCRIPTION
A worker that returns an error (or unwinds) left its slot in `active_thread_counter` behind, while `DatabaseInner::drop` spins `while counter > 0`, resending `Close` into a bounded channel nobody reads any more. One I/O error was therefore enough to make closing a database hang forever.

Move the decrement into an RAII guard so every exit path releases the slot, and cover the three exits with tests.

We have got this error in our production setup, so I ask to merge this patch or change it if you decide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker-thread tracking during normal shutdowns, errors, and unexpected failures.
  * Prevented active-thread counts from becoming inaccurate when worker threads exit.
  * Preserved correct tracking when starting a worker fails.
  * Improved reliability when worker processes stop early or encounter unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->