### PR TITLE
feat: add explicit database-wide flush

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -404,6 +404,7 @@ impl Database {
         self.supervisor.snapshot_tracker.advance_gc_watermark();
 
         for keyspace in keyspaces.values() {
+            // NOTE: lsm-tree checks for empty memtable, so we don't have to
             keyspace.tree.rotate_memtable();
 
             while keyspace.tree.sealed_memtable_count() > 0 {

--- a/src/db.rs
+++ b/src/db.rs
@@ -388,39 +388,27 @@ impl Database {
             return Err(crate::Error::Poisoned);
         }
 
-        let keyspaces = self
-            .supervisor
-            .keyspaces
-            .read()
-            .map_err(|_| crate::Error::Poisoned)?;
+        let keyspaces = self.supervisor.keyspaces.read()?;
         let watermarks = self.supervisor.build_seqno_map(&keyspaces);
 
         self.supervisor
             .journal_manager
-            .write()
-            .map_err(|_| crate::Error::Poisoned)?
+            .write()?
             .rotate_journal(&mut journal, watermarks)?;
 
         self.supervisor.snapshot_tracker.advance_gc_watermark();
 
         for keyspace in keyspaces.values() {
             keyspace.tree.rotate_memtable();
-
-            while keyspace.tree.sealed_memtable_count() > 0 {
-                run_flush(
-                    keyspace,
-                    &self.supervisor.write_buffer_size,
-                    &self.supervisor.snapshot_tracker,
-                    &self.stats,
-                )?;
-            }
+            run_flush(
+                keyspace,
+                &self.supervisor.write_buffer_size,
+                &self.supervisor.snapshot_tracker,
+                &self.stats,
+            )?;
         }
 
-        self.supervisor
-            .journal_manager
-            .write()
-            .map_err(|_| crate::Error::Poisoned)?
-            .maintenance()?;
+        self.supervisor.journal_manager.write()?.maintenance()?;
         fsync_directory(&self.config.path)?;
 
         Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -362,25 +362,25 @@ impl Database {
         Ok(())
     }
 
-    /// Flushes all journaled writes into LSM-tree tables and starts a new journal.
+    /// Synchronously flushes all keyspaces into LSM-tree tables and starts a new journal.
     ///
-    /// This blocks writes and keyspace changes for the duration of the checkpoint.
+    /// This blocks writes and keyspace changes for the duration of the operation.
     /// Reads may continue.
     /// The database remains usable afterwards, and reopening it
-    /// does not need to replay writes preceding the checkpoint.
+    /// does not need to replay writes preceding the flush.
     ///
     /// # Errors
     ///
     /// Returns an error if an I/O error occurs.
     /// A failure poisons the database.
-    pub fn checkpoint(&self) -> crate::Result<()> {
-        self.checkpoint_inner().inspect_err(|e| {
-            log::error!("Checkpoint failed, database is poisoned: {e:?}");
+    pub fn flush_all(&self) -> crate::Result<()> {
+        self.flush_all_inner().inspect_err(|e| {
+            log::error!("flush_all failed, database is poisoned: {e:?}");
             self.is_poisoned.poison();
         })
     }
 
-    fn checkpoint_inner(&self) -> crate::Result<()> {
+    fn flush_all_inner(&self) -> crate::Result<()> {
         let mut journal = self.supervisor.journal.get_writer()?;
 
         // Check after acquiring the journal lock so a concurrent failure cannot race us.

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,7 +6,7 @@ use crate::{
     batch::WriteBatch,
     db_config::Config,
     file::{fsync_directory, KEYSPACES_FOLDER, LOCK_FILE, VERSION_MARKER},
-    flush::manager::FlushManager,
+    flush::{manager::FlushManager, worker::run as run_flush},
     journal::{manager::JournalManager, writer::PersistMode, Journal},
     keyspace::{name::is_valid_keyspace_name, KeyspaceKey},
     locked_file::LockedFileGuard,
@@ -358,6 +358,67 @@ impl Database {
             );
             self.is_poisoned.poison();
         })?;
+
+        Ok(())
+    }
+
+    /// Flushes all journaled writes into LSM-tree tables and starts a new journal.
+    ///
+    /// This blocks writes and keyspace changes for the duration of the checkpoint. Reads may
+    /// continue. The database remains usable afterwards, and reopening it does not need to replay
+    /// writes preceding the checkpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if rotating the journal, flushing a keyspace, or syncing the database
+    /// directory fails. A failure poisons the database.
+    pub fn checkpoint(&self) -> crate::Result<()> {
+        self.checkpoint_inner().inspect_err(|e| {
+            log::error!("Checkpoint failed, database is poisoned: {e:?}");
+            self.is_poisoned.poison();
+        })
+    }
+
+    fn checkpoint_inner(&self) -> crate::Result<()> {
+        let mut journal = self.supervisor.journal.get_writer()?;
+
+        // Check after acquiring the journal lock so a concurrent failure cannot race us.
+        if self.is_poisoned.is_poisoned() {
+            return Err(crate::Error::Poisoned);
+        }
+
+        let keyspaces = self
+            .supervisor
+            .keyspaces
+            .read()
+            .map_err(|_| crate::Error::Poisoned)?;
+        let watermarks = self.supervisor.build_seqno_map(&keyspaces);
+
+        self.supervisor
+            .journal_manager
+            .write()
+            .map_err(|_| crate::Error::Poisoned)?
+            .rotate_journal(&mut journal, watermarks)?;
+
+        for keyspace in keyspaces.values() {
+            keyspace.tree.rotate_memtable();
+
+            while keyspace.tree.sealed_memtable_count() > 0 {
+                run_flush(
+                    keyspace,
+                    &self.supervisor.write_buffer_size,
+                    &self.supervisor.snapshot_tracker,
+                    &self.stats,
+                )?;
+            }
+        }
+
+        self.supervisor
+            .journal_manager
+            .write()
+            .map_err(|_| crate::Error::Poisoned)?
+            .maintenance()?;
+        fsync_directory(&self.config.path)?;
 
         Ok(())
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -381,6 +381,7 @@ impl Database {
     }
 
     fn flush_all_inner(&self) -> crate::Result<()> {
+        let keyspaces = self.supervisor.keyspaces.read()?;
         let mut journal = self.supervisor.journal.get_writer()?;
 
         // Check after acquiring the journal lock so a concurrent failure cannot race us.
@@ -388,7 +389,6 @@ impl Database {
             return Err(crate::Error::Poisoned);
         }
 
-        let keyspaces = self.supervisor.keyspaces.read()?;
         let watermarks = self.supervisor.build_seqno_map(&keyspaces);
 
         self.supervisor
@@ -409,6 +409,7 @@ impl Database {
             )?;
         }
 
+        self.supervisor.flush_manager.clear();
         self.supervisor.journal_manager.write()?.maintenance()?;
         fsync_directory(&self.config.path)?;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -364,14 +364,15 @@ impl Database {
 
     /// Flushes all journaled writes into LSM-tree tables and starts a new journal.
     ///
-    /// This blocks writes and keyspace changes for the duration of the checkpoint. Reads may
-    /// continue. The database remains usable afterwards, and reopening it does not need to replay
-    /// writes preceding the checkpoint.
+    /// This blocks writes and keyspace changes for the duration of the checkpoint.
+    /// Reads may continue.
+    /// The database remains usable afterwards, and reopening it
+    /// does not need to replay writes preceding the checkpoint.
     ///
     /// # Errors
     ///
-    /// Returns an error if rotating the journal, flushing a keyspace, or syncing the database
-    /// directory fails. A failure poisons the database.
+    /// Returns an error if an I/O error occurs.
+    /// A failure poisons the database.
     pub fn checkpoint(&self) -> crate::Result<()> {
         self.checkpoint_inner().inspect_err(|e| {
             log::error!("Checkpoint failed, database is poisoned: {e:?}");

--- a/src/db.rs
+++ b/src/db.rs
@@ -401,6 +401,8 @@ impl Database {
             .map_err(|_| crate::Error::Poisoned)?
             .rotate_journal(&mut journal, watermarks)?;
 
+        self.supervisor.snapshot_tracker.advance_gc_watermark();
+
         for keyspace in keyspaces.values() {
             keyspace.tree.rotate_memtable();
 

--- a/src/db_test.rs
+++ b/src/db_test.rs
@@ -1,6 +1,63 @@
 use crate::{Database, KeyspaceCreateOptions, KvSeparationOptions};
 use test_log::test;
 
+/// A checkpoint flushes every keyspace, removes the covered journal, and reopens without replay.
+#[test]
+fn checkpoint_materializes_journal() -> crate::Result<()> {
+    use crate::AbstractTree;
+
+    let folder = tempfile::tempdir()?;
+
+    {
+        let db = Database::builder(&folder)
+            .worker_threads_unchecked(0)
+            .open()?;
+        let first = db.keyspace("first", KeyspaceCreateOptions::default)?;
+        let second = db.keyspace("second", KeyspaceCreateOptions::default)?;
+
+        let mut batch = db.batch();
+        batch.insert(&first, "a", "1");
+        batch.insert(&second, "b", "2");
+        batch.commit()?;
+        first.rotate_memtable()?;
+        first.insert("c", "3")?;
+
+        let old_journal = db.supervisor.journal.path()?;
+        assert!(old_journal.metadata()?.len() > 0);
+
+        db.checkpoint()?;
+
+        let active_journal = db.supervisor.journal.path()?;
+        assert_ne!(old_journal, active_journal);
+        assert!(!old_journal.exists());
+        assert_eq!(0, db.supervisor.journal.get_writer()?.pos()?);
+        assert!(first.tree.active_memtable().is_empty());
+        assert!(second.tree.active_memtable().is_empty());
+        assert_eq!(0, first.tree.sealed_memtable_count());
+        assert_eq!(0, second.tree.sealed_memtable_count());
+
+        first.insert("d", "4")?;
+        db.checkpoint()?;
+    }
+
+    {
+        let db = Database::builder(&folder)
+            .worker_threads_unchecked(0)
+            .open()?;
+        let first = db.keyspace("first", KeyspaceCreateOptions::default)?;
+        let second = db.keyspace("second", KeyspaceCreateOptions::default)?;
+
+        assert_eq!(Some(b"1".as_slice()), first.get("a")?.as_deref());
+        assert_eq!(Some(b"2".as_slice()), second.get("b")?.as_deref());
+        assert_eq!(Some(b"3".as_slice()), first.get("c")?.as_deref());
+        assert_eq!(Some(b"4".as_slice()), first.get("d")?.as_deref());
+        assert!(first.tree.active_memtable().is_empty());
+        assert!(second.tree.active_memtable().is_empty());
+    }
+
+    Ok(())
+}
+
 #[test_log::test]
 fn clear_recover_sealed() -> crate::Result<()> {
     use crate::{Database, KeyspaceCreateOptions};

--- a/src/db_test.rs
+++ b/src/db_test.rs
@@ -1,9 +1,9 @@
 use crate::{Database, KeyspaceCreateOptions, KvSeparationOptions};
 use test_log::test;
 
-/// A checkpoint flushes every keyspace, removes the covered journal, and reopens without replay.
+/// Flushing all keyspaces removes the covered journal and allows reopening without replay.
 #[test]
-fn checkpoint_materializes_journal() -> crate::Result<()> {
+fn flush_all_materializes_journal() -> crate::Result<()> {
     use crate::AbstractTree;
 
     let folder = tempfile::tempdir()?;
@@ -25,7 +25,7 @@ fn checkpoint_materializes_journal() -> crate::Result<()> {
         let old_journal = db.supervisor.journal.path()?;
         assert!(old_journal.metadata()?.len() > 0);
 
-        db.checkpoint()?;
+        db.flush_all()?;
 
         let active_journal = db.supervisor.journal.path()?;
         assert_ne!(old_journal, active_journal);
@@ -37,7 +37,7 @@ fn checkpoint_materializes_journal() -> crate::Result<()> {
         assert_eq!(0, second.tree.sealed_memtable_count());
 
         first.insert("d", "4")?;
-        db.checkpoint()?;
+        db.flush_all()?;
     }
 
     {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
+use std::sync::PoisonError;
+
 use crate::{
     journal::error::RecoveryError as JournalRecoveryError, version::FormatVersion, CompressionType,
 };
@@ -65,6 +67,12 @@ impl From<std::io::Error> for Error {
 impl From<lsm_tree::Error> for Error {
     fn from(inner: lsm_tree::Error) -> Self {
         Self::Storage(inner)
+    }
+}
+
+impl<T> From<PoisonError<T>> for Error {
+    fn from(_: PoisonError<T>) -> Self {
+        Self::Poisoned
     }
 }
 

--- a/src/flush/worker.rs
+++ b/src/flush/worker.rs
@@ -3,26 +3,25 @@
 // (found in the LICENSE-* files in the repository)
 
 use crate::{
-    flush::Task, snapshot_tracker::SnapshotTracker, stats::Stats,
-    write_buffer_manager::WriteBufferManager,
+    snapshot_tracker::SnapshotTracker, stats::Stats, write_buffer_manager::WriteBufferManager,
+    Keyspace,
 };
 use lsm_tree::AbstractTree;
 
 /// Runs flush logic.
 pub fn run(
-    task: &Task,
+    keyspace: &Keyspace,
     write_buffer_manager: &WriteBufferManager,
     snapshot_tracker: &SnapshotTracker,
     _stats: &Stats,
 ) -> crate::Result<()> {
-    log::debug!("Flushing keyspace {:?}", task.keyspace.name);
+    log::debug!("Flushing keyspace {:?}", keyspace.name);
 
     let gc_watermark = snapshot_tracker.get_seqno_safe_to_gc();
 
-    let flush_lock = task.keyspace.tree.get_flush_lock();
+    let flush_lock = keyspace.tree.get_flush_lock();
 
-    match task
-        .keyspace
+    match keyspace
         .tree
         .flush(&flush_lock, gc_watermark)
         .inspect_err(|e| {

--- a/src/keyspace/mod.rs
+++ b/src/keyspace/mod.rs
@@ -761,8 +761,7 @@ impl Keyspace {
             // we never opened a snapshot, we need to pull the watermark up
             //
             // https://github.com/fjall-rs/fjall/discussions/85
-            self.supervisor.snapshot_tracker.pullup();
-            self.supervisor.snapshot_tracker.gc();
+            self.supervisor.snapshot_tracker.advance_gc_watermark();
 
             for keyspace in self
                 .supervisor

--- a/src/snapshot_tracker.rs
+++ b/src/snapshot_tracker.rs
@@ -133,7 +133,12 @@ impl SnapshotTracker {
             .load(std::sync::atomic::Ordering::Acquire)
     }
 
-    pub(crate) fn pullup(&self) {
+    pub(crate) fn advance_gc_watermark(&self) {
+        self.pullup();
+        self.gc();
+    }
+
+    fn pullup(&self) {
         #[expect(clippy::expect_used)]
         let _lock = self.gc_lock.write().expect("lock is poisoned");
 

--- a/src/tx/optimistic/mod.rs
+++ b/src/tx/optimistic/mod.rs
@@ -116,15 +116,15 @@ impl OptimisticTxDatabase {
         self.inner.persist(mode)
     }
 
-    /// Flushes all journaled writes into LSM-tree tables and starts a new journal.
+    /// Synchronously flushes all keyspaces into LSM-tree tables and starts a new journal.
     ///
-    /// See [`Database::checkpoint`] for details.
+    /// See [`Database::flush_all`] for details.
     ///
     /// # Errors
     ///
-    /// Returns an error if the checkpoint fails.
-    pub fn checkpoint(&self) -> crate::Result<()> {
-        self.inner.checkpoint()
+    /// Returns an error if flushing fails.
+    pub fn flush_all(&self) -> crate::Result<()> {
+        self.inner.flush_all()
     }
 
     /// Creates or opens a keyspace.

--- a/src/tx/optimistic/mod.rs
+++ b/src/tx/optimistic/mod.rs
@@ -130,6 +130,7 @@ impl OptimisticTxDatabase {
     ///
     /// items.insert("a", "hello")?;
     /// db.flush_all()?;
+    /// assert_eq!(1, items.inner().table_count());
     /// #
     /// # Ok::<_, fjall::Error>(())
     /// ```

--- a/src/tx/optimistic/mod.rs
+++ b/src/tx/optimistic/mod.rs
@@ -130,7 +130,7 @@ impl OptimisticTxDatabase {
     ///
     /// items.insert("a", "hello")?;
     /// db.flush_all()?;
-    /// assert_eq!(1, items.inner().table_count());
+    /// # assert_eq!(1, items.inner().table_count());
     /// #
     /// # Ok::<_, fjall::Error>(())
     /// ```

--- a/src/tx/optimistic/mod.rs
+++ b/src/tx/optimistic/mod.rs
@@ -116,6 +116,17 @@ impl OptimisticTxDatabase {
         self.inner.persist(mode)
     }
 
+    /// Flushes all journaled writes into LSM-tree tables and starts a new journal.
+    ///
+    /// See [`Database::checkpoint`] for details.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the checkpoint fails.
+    pub fn checkpoint(&self) -> crate::Result<()> {
+        self.inner.checkpoint()
+    }
+
     /// Creates or opens a keyspace.
     ///
     /// If the keyspace does not yet exist, it will be created configured with `create_options`.

--- a/src/tx/optimistic/mod.rs
+++ b/src/tx/optimistic/mod.rs
@@ -120,6 +120,20 @@ impl OptimisticTxDatabase {
     ///
     /// See [`Database::flush_all`] for details.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use fjall::{KeyspaceCreateOptions, OptimisticTxDatabase};
+    /// # let folder = tempfile::tempdir()?;
+    /// let db = OptimisticTxDatabase::builder(folder).open()?;
+    /// let items = db.keyspace("my_items", KeyspaceCreateOptions::default)?;
+    ///
+    /// items.insert("a", "hello")?;
+    /// db.flush_all()?;
+    /// #
+    /// # Ok::<_, fjall::Error>(())
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns an error if flushing fails.

--- a/src/tx/single_writer/mod.rs
+++ b/src/tx/single_writer/mod.rs
@@ -111,6 +111,20 @@ impl TxDatabase {
     ///
     /// See [`Database::flush_all`] for details.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use fjall::{KeyspaceCreateOptions, SingleWriterTxDatabase};
+    /// # let folder = tempfile::tempdir()?;
+    /// let db = SingleWriterTxDatabase::builder(folder).open()?;
+    /// let items = db.keyspace("my_items", KeyspaceCreateOptions::default)?;
+    ///
+    /// items.insert("a", "hello")?;
+    /// db.flush_all()?;
+    /// #
+    /// # Ok::<_, fjall::Error>(())
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns an error if flushing fails.

--- a/src/tx/single_writer/mod.rs
+++ b/src/tx/single_writer/mod.rs
@@ -107,15 +107,15 @@ impl TxDatabase {
         self.inner.persist(mode)
     }
 
-    /// Flushes all journaled writes into LSM-tree tables and starts a new journal.
+    /// Synchronously flushes all keyspaces into LSM-tree tables and starts a new journal.
     ///
-    /// See [`Database::checkpoint`] for details.
+    /// See [`Database::flush_all`] for details.
     ///
     /// # Errors
     ///
-    /// Returns an error if the checkpoint fails.
-    pub fn checkpoint(&self) -> crate::Result<()> {
-        self.inner.checkpoint()
+    /// Returns an error if flushing fails.
+    pub fn flush_all(&self) -> crate::Result<()> {
+        self.inner.flush_all()
     }
 
     /// Creates or opens a keyspace.

--- a/src/tx/single_writer/mod.rs
+++ b/src/tx/single_writer/mod.rs
@@ -121,7 +121,7 @@ impl TxDatabase {
     ///
     /// items.insert("a", "hello")?;
     /// db.flush_all()?;
-    /// assert_eq!(1, items.inner().table_count());
+    /// # assert_eq!(1, items.inner().table_count());
     /// #
     /// # Ok::<_, fjall::Error>(())
     /// ```

--- a/src/tx/single_writer/mod.rs
+++ b/src/tx/single_writer/mod.rs
@@ -121,6 +121,7 @@ impl TxDatabase {
     ///
     /// items.insert("a", "hello")?;
     /// db.flush_all()?;
+    /// assert_eq!(1, items.inner().table_count());
     /// #
     /// # Ok::<_, fjall::Error>(())
     /// ```

--- a/src/tx/single_writer/mod.rs
+++ b/src/tx/single_writer/mod.rs
@@ -107,6 +107,17 @@ impl TxDatabase {
         self.inner.persist(mode)
     }
 
+    /// Flushes all journaled writes into LSM-tree tables and starts a new journal.
+    ///
+    /// See [`Database::checkpoint`] for details.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the checkpoint fails.
+    pub fn checkpoint(&self) -> crate::Result<()> {
+        self.inner.checkpoint()
+    }
+
     /// Creates or opens a keyspace.
     ///
     /// If the keyspace does not yet exist, it will be created configured with `create_options`.

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -188,6 +188,9 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
             };
 
             {
+                #[expect(clippy::expect_used)]
+                let keyspaces = ctx.supervisor.keyspaces.read().expect("lock is poisoned");
+
                 log::trace!("acquiring journal lock to maybe rotate journal");
                 let mut journal_writer = ctx.supervisor.journal.get_writer()?;
 
@@ -199,12 +202,7 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
                         .write()
                         .expect("lock is poisoned");
 
-                    let seqno_map = {
-                        #[expect(clippy::expect_used)]
-                        let keyspaces = ctx.supervisor.keyspaces.write().expect("lock is poisoned");
-
-                        ctx.supervisor.build_seqno_map(&keyspaces)
-                    };
+                    let seqno_map = ctx.supervisor.build_seqno_map(&keyspaces);
 
                     journal_manager.rotate_journal(&mut journal_writer, seqno_map)?;
 

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -226,7 +226,7 @@ fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
             }
 
             run_flush(
-                &task,
+                &task.keyspace,
                 &ctx.supervisor.write_buffer_size,
                 &ctx.supervisor.snapshot_tracker,
                 &ctx.stats,


### PR DESCRIPTION
## What changed

- add `flush_all` to `Database` and both transactional database APIs
- rotate the journal and synchronously flush every keyspace through the production flush path
- wait for actual flush completion rather than queue emptiness
- remove journal fragments covered by persisted tables before returning

## Compatibility

This is an additive API with no file-format or configuration changes. `flush_all` temporarily blocks writes and keyspace changes while reads continue; the database remains writable afterwards.

Closes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public operation to synchronously flush pending writes across all keyspaces.
  * Flushes data into durable storage, starts a fresh journal, and preserves continued writes.
  * Data remains available after closing and reopening the database.

* **Bug Fixes**
  * Improved error handling and database safety when synchronization fails.
  * Improved snapshot cleanup, journal maintenance, and durability during flush operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->