### PR TITLE
Potential bug and fix for missing file extensions

### DIFF
--- a/src/journal/recovery.rs
+++ b/src/journal/recovery.rs
@@ -81,7 +81,7 @@ pub fn recover_journals<P: AsRef<Path>>(
             active: {
                 let id: JournalId = max_journal_id + 1;
 
-                Journal::create_new(path.join(id.to_string()))?
+                Journal::create_new(path.join(format!("{id}.jnl")))?
                     .with_compression(compression, compression_threshold)
             },
             sealed: vec![],

--- a/tests/recovery_journal_missing.rs
+++ b/tests/recovery_journal_missing.rs
@@ -1,0 +1,35 @@
+use fjall::{Database, PersistMode};
+use test_log::test;
+
+// Recovered journal files are properly serialized.
+#[test]
+fn db_journal_recovery_no_journal_files() -> fjall::Result<()> {
+    let folder = tempfile::tempdir()?;
+
+    {
+        let _db = Database::builder(&folder).open()?;
+    }
+
+    for dirent in std::fs::read_dir(&folder)? {
+        let path = dirent?.path();
+
+        if path.extension().is_some_and(|ext| ext == "jnl") {
+            std::fs::remove_file(path)?;
+        }
+    }
+
+    {
+        let db = Database::builder(&folder).open()?;
+        let tree = db.keyspace("default", Default::default)?;
+        tree.insert("hello", "world")?;
+        db.persist(PersistMode::SyncAll)?;
+    }
+
+    {
+        let db = Database::builder(&folder).open()?;
+        let tree = db.keyspace("default", Default::default)?;
+        assert_eq!(Some("world".as_bytes().into()), tree.get("hello")?);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
While looking into fjall's file structure, we came across the following potential issue. During recovery, the `.jni` file extension isn't included in the recovered journal file. As a result, changes after recovery are not persisted. I'm not sure how this is feasible in practice, but I've included a test and fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved journal recovery when existing journal fragments are missing.
  - Ensures newly created recovery journal files use the correct filename format.
  - Preserves data written after recovery across subsequent database reopenings.

- **Tests**
  - Added coverage for recovering from deleted journal files and verifying data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->