### PR TITLE
WIP: fix: don't flood the worker mailbox with rotate pokes (sketching)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -19,7 +19,7 @@ use crate::{
     supervisor::{Supervisor, SupervisorInner},
     tx::single_writer::Openable,
     version::FormatVersion,
-    worker_pool::{WorkerMessage, WorkerPool},
+    worker_pool::WorkerPool,
     write_buffer_manager::WriteBufferManager,
     HashMap, Keyspace, KeyspaceCreateOptions,
 };
@@ -66,19 +66,14 @@ impl Drop for DatabaseInner {
 
         self.stop_signal.send();
 
-        let _ = self.worker_pool.rx.drain().count();
-
         while self
             .active_thread_counter
             .load(std::sync::atomic::Ordering::Relaxed)
             > 0
         {
-            let _ = self.worker_pool.sender.send(WorkerMessage::Close);
+            self.worker_pool.poke();
             std::thread::sleep(std::time::Duration::from_micros(10));
         }
-
-        // Drain again after threads are closed
-        let _ = self.worker_pool.rx.drain().count();
 
         // IMPORTANT: Break cyclic Arcs
         self.supervisor.flush_manager.clear();
@@ -779,17 +774,14 @@ impl Database {
                         keyspace: keyspace.clone(),
                     }));
 
-                keyspace.worker_messager.send(WorkerMessage::Flush).ok();
+                keyspace.poke_workers();
             } else if keyspace.tree.l0_run_count() > 0 {
                 log::debug!(
                     "Queuing keyspace {:?} to maybe get compacted because L0 runs > 0",
                     keyspace.name(),
                 );
 
-                keyspace
-                    .worker_messager
-                    .send(WorkerMessage::Compact(keyspace.clone()))
-                    .ok();
+                keyspace.request_compact();
             }
         }
 
@@ -799,6 +791,7 @@ impl Database {
             &db.stats,
             &PoisonDart::new(db.is_poisoned.clone()),
             &db.active_thread_counter,
+            &db.stop_signal,
         )?;
 
         log::trace!("Database recovery successful");
@@ -906,6 +899,7 @@ impl Database {
             &db.stats,
             &PoisonDart::new(db.is_poisoned.clone()),
             &db.active_thread_counter,
+            &db.stop_signal,
         )?;
 
         Ok(db)

--- a/src/ingestion.rs
+++ b/src/ingestion.rs
@@ -2,7 +2,7 @@
 // This source code is licensed under both the Apache 2.0 and MIT License
 // (found in the LICENSE-* files in the repository)
 
-use crate::{worker_pool::WorkerMessage, Keyspace};
+use crate::Keyspace;
 use lsm_tree::{AnyIngestion, UserKey, UserValue};
 
 pub struct Ingestion<'a> {
@@ -54,10 +54,7 @@ impl<'a> Ingestion<'a> {
         self.inner
             .finish()
             .inspect(|()| {
-                self.keyspace
-                    .worker_messager
-                    .try_send(WorkerMessage::Compact(self.keyspace.clone()))
-                    .ok();
+                self.keyspace.request_compact();
 
                 self.keyspace.supervisor.snapshot_tracker.gc();
             })

--- a/src/keyspace/mod.rs
+++ b/src/keyspace/mod.rs
@@ -18,7 +18,6 @@ use crate::{
     poison::PoisonSignal,
     stats::Stats,
     supervisor::Supervisor,
-    worker_pool::WorkerMessage,
     Database, Guard, Iter,
 };
 use lsm_tree::{AbstractTree, AnyTree, SeqNo, UserKey, UserValue};
@@ -86,7 +85,13 @@ pub struct KeyspaceInner {
     /// Database-level stats
     pub(crate) stats: Arc<Stats>,
 
-    pub(crate) worker_messager: flume::Sender<WorkerMessage>,
+    pub(crate) worker_wake: flume::Sender<()>,
+
+    /// Coalesces rotate pokes: one outstanding "please rotate" per keyspace.
+    rotate_pending: AtomicBool,
+
+    /// Coalesces compact pokes. Cleared when a worker takes the compact.
+    compact_pending: AtomicBool,
 
     #[expect(unused)]
     lock_file: LockedFileGuard,
@@ -316,9 +321,11 @@ impl Keyspace {
             tree,
             config,
             supervisor: db.supervisor.clone(),
-            worker_messager: db.worker_pool.sender.clone(),
+            worker_wake: db.worker_pool.wake.clone(),
             is_deleted: AtomicBool::default(),
             is_poisoned: db.is_poisoned.clone(),
+            rotate_pending: AtomicBool::new(false),
+            compact_pending: AtomicBool::new(false),
             lock_file: db.lock_file.clone(),
             stats: db.stats.clone(),
         }))
@@ -354,13 +361,15 @@ impl Keyspace {
 
         Ok(Self(Arc::new(KeyspaceInner {
             supervisor: db.supervisor.clone(),
-            worker_messager: db.worker_pool.sender.clone(),
+            worker_wake: db.worker_pool.wake.clone(),
             id: keyspace_id,
             name,
             config,
             tree,
             is_deleted: AtomicBool::default(),
             is_poisoned: db.is_poisoned.clone(),
+            rotate_pending: AtomicBool::new(false),
+            compact_pending: AtomicBool::new(false),
             stats: db.stats.clone(),
             lock_file: db.lock_file.clone(),
         })))
@@ -754,7 +763,7 @@ impl Keyspace {
             keyspace: self.clone(),
         }));
 
-        self.worker_messager.send(WorkerMessage::Flush).ok();
+        self.poke_workers();
 
         {
             // NOTE: If the difference between watermark is too large, and
@@ -823,16 +832,43 @@ impl Keyspace {
     }
 
     pub(crate) fn request_rotation(&self) {
-        let lock = self.tree.get_version_history_lock();
-        let latest_version = lock.latest_version();
-        let active_memtable = &latest_version.active_memtable;
+        if self
+            .rotate_pending
+            .swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            return;
+        }
+        self.poke_workers();
+    }
 
-        self.worker_messager
-            .try_send(WorkerMessage::RotateMemtable(
-                self.clone(),
-                active_memtable.id(),
-            ))
-            .ok();
+    pub(crate) fn poke_workers(&self) {
+        self.worker_wake.try_send(()).ok();
+    }
+
+    pub(crate) fn request_compact(&self) {
+        if self
+            .compact_pending
+            .swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            return;
+        }
+        self.poke_workers();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn compact_is_pending(&self) -> bool {
+        self.compact_pending
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn take_rotate_pending(&self) -> bool {
+        self.rotate_pending
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn take_compact_pending(&self) -> bool {
+        self.compact_pending
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
     }
 
     pub(crate) fn check_memtable_rotate(&self, size: u64) {

--- a/src/keyspace/test.rs
+++ b/src/keyspace/test.rs
@@ -68,7 +68,7 @@ fn keyspace_ingest() -> crate::Result<()> {
     assert_eq!(15, items.len()?);
     assert_eq!(4, items.table_count());
 
-    while !db.worker_pool.sender.is_empty() {}
+    while !db.worker_pool.wake.is_empty() {}
     assert_eq!(1, items.table_count());
 
     Ok(())

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -3,12 +3,15 @@
 // (found in the LICENSE-* files in the repository)
 
 use crate::{
-    compaction::worker::run as run_compaction, flush::worker::run as run_flush, poison::PoisonDart,
-    stats::Stats, supervisor::Supervisor, Keyspace,
+    compaction::worker::run as run_compaction,
+    flush::{worker::run as run_flush, Task as FlushTask},
+    poison::PoisonDart,
+    stats::Stats,
+    supervisor::Supervisor,
+    Keyspace,
 };
-use lsm_tree::MemtableId;
+use lsm_tree::AbstractTree;
 use std::{
-    borrow::Cow,
     sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
         Arc, Mutex,
@@ -16,46 +19,28 @@ use std::{
     thread::JoinHandle,
 };
 
-pub enum WorkerMessage {
-    Flush,
-    Compact(Keyspace),
-    Close,
-    RotateMemtable(Keyspace, MemtableId),
-}
-
-impl std::fmt::Debug for WorkerMessage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Flush => Cow::Borrowed("WorkerMessage:Flush"),
-                Self::Compact(k) => Cow::Owned(format!("WorkerMessage:Compact({:?})", k.name)),
-                Self::Close => Cow::Borrowed("WorkerMessage:Close"),
-                Self::RotateMemtable(k, memtable_id) =>
-                    Cow::Owned(format!("WorkerMessage:Rotate({:?}, {memtable_id})", k.name)),
-            }
-        )
-    }
-}
-
 type WorkerHandle = JoinHandle<Result<(), crate::Error>>;
 
 pub struct WorkerPool {
     thread_handles: Mutex<Vec<WorkerHandle>>,
-    pub(crate) rx: flume::Receiver<WorkerMessage>,
-    pub(crate) sender: flume::Sender<WorkerMessage>,
+    /// One slot. Extra pokes while a worker is already awake are dropped.
+    pub(crate) wake: flume::Sender<()>,
+    wake_rx: flume::Receiver<()>,
 }
 
 impl WorkerPool {
     pub fn prepare() -> Self {
-        let (sender, rx) = flume::bounded(1_000);
+        let (wake, wake_rx) = flume::bounded(1);
 
         Self {
             thread_handles: Mutex::default(),
-            rx,
-            sender,
+            wake,
+            wake_rx,
         }
+    }
+
+    pub(crate) fn poke(&self) {
+        self.wake.try_send(()).ok();
     }
 
     pub fn start(
@@ -65,6 +50,7 @@ impl WorkerPool {
         stats: &Arc<Stats>,
         poison_dart: &PoisonDart,
         thread_counter: &Arc<AtomicUsize>,
+        stop: &lsm_tree::stop_signal::StopSignal,
     ) -> crate::Result<()> {
         log::debug!("Starting worker pool with {pool_size} threads");
 
@@ -75,12 +61,11 @@ impl WorkerPool {
                     log::trace!("Starting fjall worker thread #{i}");
 
                     let worker_state = WorkerState {
-                        pool_size,
-                        worker_id: i,
-                        rx: self.rx.clone(),
+                        wake: self.wake.clone(),
+                        wake_rx: self.wake_rx.clone(),
                         supervisor: supervisor.clone(),
                         stats: stats.clone(),
-                        sender: self.sender.clone(),
+                        stop: stop.clone(),
                     };
 
                     let thread_counter = thread_counter.clone();
@@ -158,106 +143,122 @@ impl Drop for ActiveThreadGuard {
 }
 
 struct WorkerState {
-    pool_size: usize,
-    worker_id: usize,
     supervisor: Supervisor,
-    rx: flume::Receiver<WorkerMessage>,
-    sender: flume::Sender<WorkerMessage>,
+    wake: flume::Sender<()>,
+    wake_rx: flume::Receiver<()>,
     stats: Arc<Stats>,
+    stop: lsm_tree::stop_signal::StopSignal,
+}
+
+impl WorkerState {
+    fn poke(&self) {
+        self.wake.try_send(()).ok();
+    }
 }
 
 fn worker_tick(ctx: &WorkerState) -> crate::Result<bool> {
-    let Ok(item) = ctx.rx.recv() else {
+    if ctx.stop.is_stopped() {
         return Ok(true);
-    };
+    }
 
-    log::trace!("Worker #{} got message: {item:?}", ctx.worker_id);
+    if let Some(task) = ctx.supervisor.flush_manager.dequeue() {
+        ctx.poke();
+        process_one_flush(ctx, task.as_ref())?;
+        return Ok(false);
+    }
 
-    match item {
-        WorkerMessage::Close => {
-            return Ok(true);
-        }
-        WorkerMessage::RotateMemtable(keyspace, memtable_id) => {
+    if run_pending_keyspace_work(ctx)? {
+        ctx.poke();
+        return Ok(false);
+    }
+
+    if ctx.stop.is_stopped() {
+        return Ok(true);
+    }
+
+    Ok(ctx.wake_rx.recv().is_err())
+}
+
+fn run_pending_keyspace_work(ctx: &WorkerState) -> crate::Result<bool> {
+    let keyspaces: Vec<Keyspace> = ctx
+        .supervisor
+        .keyspaces
+        .read()
+        .expect("lock is poisoned")
+        .values()
+        .cloned()
+        .collect();
+
+    for keyspace in keyspaces {
+        if keyspace.take_rotate_pending() {
             log::trace!("acquiring journal lock");
             let journal_writer = keyspace.supervisor.journal.get_writer()?;
+            let memtable_id = keyspace.tree.active_memtable().id();
             keyspace.inner_rotate_memtable(journal_writer, memtable_id)?;
+            return Ok(true);
         }
-        WorkerMessage::Flush => {
-            let Some(task) = ctx.supervisor.flush_manager.dequeue() else {
-                return Ok(false);
-            };
 
-            {
-                log::trace!("acquiring journal lock to maybe rotate journal");
-                let mut journal_writer = ctx.supervisor.journal.get_writer()?;
-
-                if journal_writer.pos()? > 64_000_000 {
-                    #[expect(clippy::expect_used)]
-                    let mut journal_manager = ctx
-                        .supervisor
-                        .journal_manager
-                        .write()
-                        .expect("lock is poisoned");
-
-                    let seqno_map = {
-                        #[expect(clippy::expect_used)]
-                        let keyspaces = ctx.supervisor.keyspaces.write().expect("lock is poisoned");
-
-                        ctx.supervisor.build_seqno_map(&keyspaces)
-                    };
-
-                    journal_manager.rotate_journal(&mut journal_writer, seqno_map)?;
-
-                    if journal_manager.disk_space_used()
-                        >= ctx.supervisor.db_config.max_journaling_size_in_bytes
-                    {
-                        let stragglers =
-                            journal_manager.get_keyspaces_to_flush_for_oldest_journal_eviction();
-
-                        for keyspace in stragglers {
-                            log::info!(
-                                "Rotating {:?} to try to reduce journal size",
-                                keyspace.name,
-                            );
-                            keyspace.request_rotation();
-                        }
-                    }
-                }
-            }
-
-            run_flush(
-                &task,
-                &ctx.supervisor.write_buffer_size,
-                &ctx.supervisor.snapshot_tracker,
-                &ctx.stats,
-            )?;
-
-            for _ in 0..ctx.pool_size {
-                ctx.sender
-                    .try_send(WorkerMessage::Compact(task.keyspace.clone()))
-                    .ok();
-            }
-
-            ctx.supervisor
-                .journal_manager
-                .write()
-                .expect("lock is poisoned")
-                .maintenance()?;
-        }
-        WorkerMessage::Compact(keyspace) => {
-            // NOTE: Let one worker prioritize flushing if there are pending flushes
-            //
-            // Disable when only 1 worker exists to avoid deadlock
-            if ctx.pool_size > 1 && ctx.worker_id == 0 {
-                ctx.sender.send(WorkerMessage::Compact(keyspace)).ok();
-                return Ok(false);
-            }
-
+        if keyspace.take_compact_pending() {
             run_compaction(&keyspace, &ctx.supervisor.snapshot_tracker, &ctx.stats)?;
+            return Ok(true);
         }
     }
 
     Ok(false)
+}
+
+fn process_one_flush(ctx: &WorkerState, task: &FlushTask) -> crate::Result<()> {
+    {
+        log::trace!("acquiring journal lock to maybe rotate journal");
+        let mut journal_writer = ctx.supervisor.journal.get_writer()?;
+
+        if journal_writer.pos()? > 64_000_000 {
+            #[expect(clippy::expect_used)]
+            let mut journal_manager = ctx
+                .supervisor
+                .journal_manager
+                .write()
+                .expect("lock is poisoned");
+
+            let seqno_map = {
+                #[expect(clippy::expect_used)]
+                let keyspaces = ctx.supervisor.keyspaces.write().expect("lock is poisoned");
+
+                ctx.supervisor.build_seqno_map(&keyspaces)
+            };
+
+            journal_manager.rotate_journal(&mut journal_writer, seqno_map)?;
+
+            if journal_manager.disk_space_used()
+                >= ctx.supervisor.db_config.max_journaling_size_in_bytes
+            {
+                let stragglers =
+                    journal_manager.get_keyspaces_to_flush_for_oldest_journal_eviction();
+
+                for keyspace in stragglers {
+                    log::info!("Rotating {:?} to try to reduce journal size", keyspace.name,);
+                    keyspace.request_rotation();
+                }
+            }
+        }
+    }
+
+    run_flush(
+        task,
+        &ctx.supervisor.write_buffer_size,
+        &ctx.supervisor.snapshot_tracker,
+        &ctx.stats,
+    )?;
+
+    task.keyspace.request_compact();
+
+    ctx.supervisor
+        .journal_manager
+        .write()
+        .expect("lock is poisoned")
+        .maintenance()?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -293,15 +294,10 @@ mod tests {
                 .worker_threads_unchecked(0)
                 .open()?;
 
-            assert_eq!(
-                1,
-                db.worker_pool.rx.len(),
-                "worker message should be enqueued on startup",
-            );
-            let item = db.worker_pool.rx.try_recv().expect("should get message");
+            let ks = db.keyspace("default", KeyspaceCreateOptions::default)?;
             assert!(
-                matches!(item, WorkerMessage::Compact(_)),
-                "worker message should be compaction request",
+                ks.compact_is_pending(),
+                "compaction should be pending on startup when L0 exists",
             );
         }
 

--- a/tests/worker_pool_starvation.rs
+++ b/tests/worker_pool_starvation.rs
@@ -1,0 +1,72 @@
+use fjall::{Database, KeyspaceCreateOptions};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::Duration;
+use test_log::test;
+
+const MAX_MEMTABLE_SIZE: u64 = 128 * 1_024;
+const INSERTS: u64 = 100_000;
+const VALUE_LEN: usize = 64;
+const MIN_FLUSHED_PCT: f64 = 50.0;
+const ROTATE_BUDGET: Duration = Duration::from_secs(5);
+
+fn flush_under_load(worker_threads: usize) -> fjall::Result<()> {
+    let folder = tempfile::tempdir()?;
+
+    let db = Database::builder(&folder)
+        .worker_threads(worker_threads)
+        .open()?;
+
+    let keyspace = db.keyspace("default", || {
+        KeyspaceCreateOptions::default().max_memtable_size(MAX_MEMTABLE_SIZE)
+    })?;
+
+    let value = vec![b'v'; VALUE_LEN];
+    for i in 0..INSERTS {
+        keyspace.insert(i.to_be_bytes(), &value)?;
+    }
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn({
+        let keyspace = keyspace.clone();
+        move || {
+            let _ = tx.send(keyspace.rotate_memtable_and_wait());
+        }
+    });
+
+    let rotate = match rx.recv_timeout(ROTATE_BUDGET) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout) => {
+            // `DatabaseInner::drop` waits for the worker counter to hit zero,
+            // so dropping a stuck pool hangs the test.
+            std::mem::forget(keyspace);
+            std::mem::forget(db);
+            std::mem::forget(folder);
+            panic!("rotate_memtable_and_wait blocked for {ROTATE_BUDGET:?}");
+        }
+        Err(RecvTimeoutError::Disconnected) => {
+            panic!("rotate_memtable_and_wait thread panicked")
+        }
+    };
+    rotate?;
+
+    let bytes_written = INSERTS * (8 + VALUE_LEN as u64);
+    let segment_bytes = keyspace.disk_space();
+    let flushed_pct = segment_bytes as f64 / bytes_written as f64 * 100.0;
+    assert!(
+        flushed_pct >= MIN_FLUSHED_PCT,
+        "only {flushed_pct:.1}% of written bytes reached segments \
+         ({segment_bytes} of {bytes_written})",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn flush_with_one_worker() -> fjall::Result<()> {
+    flush_under_load(1)
+}
+
+#[test]
+fn flush_with_two_workers() -> fjall::Result<()> {
+    flush_under_load(2)
+}


### PR DESCRIPTION
A worker that `send(Flush)`s on the same bounded channel it reads deadlocks when write load fills that channel with `RotateMemtable`. Easy with one worker (only receiver). Can still happen with more if every worker is in `send` on a full channel.

Work is not a pile of duplicate pokes anymore. Each keyspace has `rotate_pending` / `compact_pending`. Flush still lives in `FlushManager`. The mailbox is `Look` (wake) and `Close`. Writers set a bit and poke once. Workers look at pending work before they sleep.

`tests/worker_pool_starvation.rs` is the one- and two-worker write load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memtable flushing under heavy write loads.
  - Reduced the risk of worker-pool starvation and blocking during flush and compaction processing.
  - Ensured queued flush tasks are processed promptly, improving reliability for single- and multi-worker configurations.
  - Improved background scheduling for memtable rotation and compaction after recovery and ingestion.

- **Tests**
  - Added coverage for flushing large workloads with one or two worker threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->